### PR TITLE
Feature/state

### DIFF
--- a/shell/config.go
+++ b/shell/config.go
@@ -1,13 +1,15 @@
 package shell
 
+//Config is the config for the client.
 type Config struct {
 }
 
-type ShellClient struct {
+//Client is the client itself. Since we already have access to the shell no real provisioning needs to be done
+type Client struct {
 }
 
 // Client configures and returns a fully initialized ShellClient
 func (c *Config) Client() (interface{}, error) {
-	var client ShellClient
+	var client Client
 	return &client, nil
 }

--- a/shell/data_source_shell_script.go
+++ b/shell/data_source_shell_script.go
@@ -1,20 +1,11 @@
 package shell
 
 import (
-	"bytes"
-	"crypto/rand"
-	"crypto/sha256"
-	"encoding/hex"
-	"encoding/json"
 	"fmt"
-	"io"
 	"log"
-	"os"
-	"os/exec"
-	"runtime"
 
-	"github.com/armon/circbuf"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/rs/xid"
 )
 
 func dataSourceShellScript() *schema.Resource {
@@ -59,6 +50,7 @@ func dataSourceShellScript() *schema.Resource {
 }
 
 func dataSourceShellScriptRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Reading shell script data resource...")
 	l := d.Get("lifecycle_commands").([]interface{})
 	c := l[0].(map[string]interface{})
 	value := c["read"]
@@ -84,105 +76,8 @@ func dataSourceShellScriptRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.Set("output", newState.output)
 
-	//create random uuid for the id, changes to inputs will prompt update or recreate so it doesn't need to change
-	idBytes := make([]byte, 16)
-	_, randErr := rand.Read(idBytes)
-	if randErr != nil {
-		return randErr
-	}
-	d.SetId(hash(string(idBytes[0:])))
+	//create random uuid for the id
+	id := xid.New().String()
+	d.SetId(id)
 	return nil
-}
-
-func readEnvironmentVariables(ev map[string]interface{}) []string {
-	var variables []string
-	if ev != nil {
-		for k, v := range ev {
-			variables = append(variables, k+"="+v.(string))
-		}
-	}
-	return variables
-}
-
-func hash(s string) string {
-	sha := sha256.Sum256([]byte(s))
-	return hex.EncodeToString(sha[:])
-}
-
-func parseJSON(b []byte) (map[string]string, error) {
-	tb := bytes.Trim(b, "\x00")
-	s := string(tb)
-	var f map[string]interface{}
-	err := json.Unmarshal([]byte(s), &f)
-	output := make(map[string]string)
-	for k, v := range f {
-		output[k] = v.(string)
-	}
-	return output, err
-}
-
-func runCommand(command string, state *State, environment []string, workingDirectory string) (*State, error) {
-	const maxBufSize = 8 * 1024
-	// Execute the command using a shell
-	var shell, flag string
-	if runtime.GOOS == "windows" {
-		shell = "cmd"
-		flag = "/C"
-	} else {
-		shell = "/bin/sh"
-		flag = "-c"
-	}
-
-	// Setup the command
-	command = fmt.Sprintf("cd %s && %s", workingDirectory, command)
-	cmd := exec.Command(shell, flag, command)
-	input, _ := json.Marshal(state)
-	stdin := bytes.NewReader(input)
-	cmd.Stdin = stdin
-	environment = append(environment, os.Environ()...)
-	cmd.Env = environment
-	stdout, _ := circbuf.NewBuffer(maxBufSize)
-	stderr, _ := circbuf.NewBuffer(maxBufSize)
-	cmd.Stderr = io.Writer(stderr)
-	cmd.Stdout = io.Writer(stdout)
-	pr, pw, err := os.Pipe()
-	cmd.ExtraFiles = []*os.File{pw}
-
-	// Output what we're about to run
-	log.Printf("[DEBUG] shell script going to execute: %s %s \"%s\"", shell, flag, command)
-
-	// Run the command to completion
-	err = cmd.Run()
-	if err != nil {
-		return nil, fmt.Errorf("Error running command '%s': '%v'", command, err)
-	}
-
-	log.Printf("[DEBUG] Command execution completed. Reading from output pipe: >&3")
-	//read back diff output from pipe
-	data := make([]byte, maxBufSize)
-	pr.Read(data)
-	pw.Close()
-	pr.Close()
-	log.Printf("[DEBUG] data raw text from pipe: %s", string(data))
-	output, err := parseJSON(data)
-	if err != nil {
-		return nil, fmt.Errorf("Error unmarshalling data to map[string]string: '%v'", err)
-	}
-	newState := NewState(environment, output)
-
-	log.Printf("[DEBUG] shell script command stdout: \"%s\"", stdout.String())
-	log.Printf("[DEBUG] shell script command stderr: \"%s\"", stderr.String())
-	log.Printf("[DEBUG] shell script command state: \"%v\"", newState)
-	return newState, nil
-}
-
-// State is a wrapper around both the input and output attributes that are relavent for updates
-type State struct {
-	environment []string          `json:"environment"`
-	output      map[string]string `json:"output"`
-}
-
-// NewState is the constructor for State
-func NewState(environment []string, output map[string]string) *State {
-	return &State{environment: environment, output: output}
 }

--- a/shell/resource_shell_script.go
+++ b/shell/resource_shell_script.go
@@ -1,6 +1,8 @@
 package shell
 
 import (
+	"crypto/rand"
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -11,6 +13,7 @@ func resourceShellScript() *schema.Resource {
 		Create: resourceShellScriptCreate,
 		Delete: resourceShellScriptDelete,
 		Read:   resourceShellScriptRead,
+		Update: resourceShellScriptUpdate,
 		Schema: map[string]*schema.Schema{
 			"lifecycle_commands": {
 				Type:     schema.TypeList,
@@ -24,11 +27,15 @@ func resourceShellScript() *schema.Resource {
 							Required: true,
 							ForceNew: true,
 						},
+						"update": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
 						"read": {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: true,
-							Default:  "IN=$(cat)\necho $IN",
 						},
 						"delete": {
 							Type:     schema.TypeString,
@@ -41,7 +48,6 @@ func resourceShellScript() *schema.Resource {
 			"environment": {
 				Type:     schema.TypeMap,
 				Optional: true,
-				ForceNew: true,
 				Elem:     schema.TypeString,
 			},
 			"working_directory": {
@@ -49,14 +55,6 @@ func resourceShellScript() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				Default:  ".",
-			},
-			"stderr": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"stdout": {
-				Type:     schema.TypeString,
-				Computed: true,
 			},
 			"output": {
 				Type:     schema.TypeMap,
@@ -67,6 +65,119 @@ func resourceShellScript() *schema.Resource {
 	}
 }
 
+func resourceShellScriptCreate(d *schema.ResourceData, meta interface{}) error {
+	l := d.Get("lifecycle_commands").([]interface{})
+	c := l[0].(map[string]interface{})
+	command := c["create"].(string)
+	vars := d.Get("environment").(map[string]interface{})
+	environment := readEnvironmentVariables(vars)
+
+	workingDirectory := d.Get("working_directory").(string)
+
+	//obtain exclusive lock
+	shellMutexKV.Lock(shellScriptMutexKey)
+	defer shellMutexKV.Unlock(shellScriptMutexKey)
+
+	output := make(map[string]string)
+	state := NewState(environment, output)
+	newState, err := runCommand(command, state, environment, workingDirectory)
+	if err != nil {
+		return err
+	}
+
+	//once creation has finished setup state so update works
+	if newState == nil {
+		//otherwise set state fix the read()
+		if err := resourceShellScriptRead(d, meta); err != nil {
+			return err
+		}
+	} else {
+		d.Set("output", newState.output)
+	}
+
+	//create random uuid for the id, changes to inputs will prompt update or recreate so it doesn't need to change
+	idBytes := make([]byte, 16)
+	_, randErr := rand.Read(idBytes)
+	if randErr != nil {
+		return randErr
+	}
+	d.SetId(hash(string(idBytes[0:])))
+	return nil
+}
+
+func resourceShellScriptRead(d *schema.ResourceData, meta interface{}) error {
+	l := d.Get("lifecycle_commands").([]interface{})
+	c := l[0].(map[string]interface{})
+	value := c["read"]
+
+	//if read is not set then do nothing. assume create is setting the state and it never needs to
+	//be synchronized with the remote state
+	if value == nil {
+		return nil
+	}
+
+	command := value.(string)
+	vars := d.Get("environment").(map[string]interface{})
+	environment := readEnvironmentVariables(vars)
+	workingDirectory := d.Get("working_directory").(string)
+	output := d.Get("output").(map[string]string)
+
+	//obtain exclusive lock
+	shellMutexKV.Lock(shellScriptMutexKey)
+	defer shellMutexKV.Unlock(shellScriptMutexKey)
+
+	state := NewState(environment, output)
+	newState, err := runCommand(command, state, environment, workingDirectory)
+	if err != nil {
+		return err
+	}
+
+	if newState == nil {
+		return fmt.Errorf("Error: state from read operation cannot be nil")
+	}
+	d.Set("output", newState.output)
+	return nil
+}
+
+func resourceShellScriptUpdate(d *schema.ResourceData, meta interface{}) error {
+	l := d.Get("lifecycle_commands").([]interface{})
+	c := l[0].(map[string]interface{})
+	value := c["update"]
+
+	//if update is not set, then treat it simply as a tainted resource
+	if value == nil {
+		resourceShellScriptDelete(d, meta)
+		return resourceShellScriptCreate(d, meta)
+	}
+
+	command := value.(string)
+	vars := d.Get("environment").(map[string]interface{})
+	environment := readEnvironmentVariables(vars)
+	workingDirectory := d.Get("working_directory").(string)
+	output := d.Get("output").(map[string]string)
+
+	//obtain exclusive lock
+	shellMutexKV.Lock(shellScriptMutexKey)
+	defer shellMutexKV.Unlock(shellScriptMutexKey)
+
+	state := NewState(environment, output)
+	newState, err := runCommand(command, state, environment, workingDirectory)
+	if err != nil {
+		return err
+	}
+
+	//once creation has finished setup state so update works
+	if newState == nil {
+		//otherwise set state fix the read()
+		if err := resourceShellScriptRead(d, meta); err != nil {
+			return err
+		}
+	} else {
+		d.Set("output", newState.output)
+	}
+	return nil
+}
+
 func resourceShellScriptDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Deleting shell script resource")
 	l := d.Get("lifecycle_commands").([]interface{})
@@ -75,77 +186,18 @@ func resourceShellScriptDelete(d *schema.ResourceData, meta interface{}) error {
 	vars := d.Get("environment").(map[string]interface{})
 	environment := readEnvironmentVariables(vars)
 	workingDirectory := d.Get("working_directory").(string)
-	input := d.Get("stdout").(string)
+	output := d.Get("output").(map[string]string)
+
 	//obtain exclusive lock
 	shellMutexKV.Lock(shellScriptMutexKey)
 	defer shellMutexKV.Unlock(shellScriptMutexKey)
 
-	_, _, err := runCommand(command, input, environment, workingDirectory)
+	state := NewState(environment, output)
+	_, err := runCommand(command, state, environment, workingDirectory)
 	if err != nil {
 		return err
 	}
 
 	d.SetId("")
-	return nil
-}
-func resourceShellScriptCreate(d *schema.ResourceData, meta interface{}) error {
-	l := d.Get("lifecycle_commands").([]interface{})
-	c := l[0].(map[string]interface{})
-	command := c["create"].(string)
-	vars := d.Get("environment").(map[string]interface{})
-	environment := readEnvironmentVariables(vars)
-	workingDirectory := d.Get("working_directory").(string)
-	var input string
-	//obtain exclusive lock
-	shellMutexKV.Lock(shellScriptMutexKey)
-	defer shellMutexKV.Unlock(shellScriptMutexKey)
-
-	stdout, stderr, err := runCommand(command, input, environment, workingDirectory)
-	if err != nil {
-		return err
-	}
-	output, err := parseJSON(stdout)
-	if err != nil {
-		log.Printf("[DEBUG] error parsing sdout into json: %v", err)
-		output = make(map[string]string)
-		d.Set("output", output)
-	} else {
-		d.Set("output", output)
-	}
-
-	d.Set("stdout", stdout)
-	d.Set("stderr", stderr)
-	d.SetId(hash(command))
-	return nil
-}
-
-func resourceShellScriptRead(d *schema.ResourceData, meta interface{}) error {
-	l := d.Get("lifecycle_commands").([]interface{})
-	c := l[0].(map[string]interface{})
-	command := c["read"].(string)
-	vars := d.Get("environment").(map[string]interface{})
-	environment := readEnvironmentVariables(vars)
-	workingDirectory := d.Get("working_directory").(string)
-	input := d.Get("stdout").(string)
-
-	//obtain exclusive lock
-	shellMutexKV.Lock(shellScriptMutexKey)
-	defer shellMutexKV.Unlock(shellScriptMutexKey)
-
-	stdout, stderr, err := runCommand(command, input, environment, workingDirectory)
-	if err != nil {
-		return err
-	}
-	output, err := parseJSON(stdout)
-	if err != nil {
-		log.Printf("[DEBUG] error parsing sdout into json: %v", err)
-		var output map[string]string
-		d.Set("output", output)
-	} else {
-		d.Set("output", output)
-	}
-
-	d.Set("stdout", stdout)
-	d.Set("stderr", stderr)
 	return nil
 }

--- a/shell/utility.go
+++ b/shell/utility.go
@@ -1,0 +1,105 @@
+package shell
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"runtime"
+
+	"github.com/armon/circbuf"
+)
+
+// State is a wrapper around both the input and output attributes that are relavent for updates
+type State struct {
+	environment []string
+	output      map[string]string
+}
+
+// NewState is the constructor for State
+func NewState(environment []string, output map[string]string) *State {
+	return &State{environment: environment, output: output}
+}
+
+func readEnvironmentVariables(ev map[string]interface{}) []string {
+	var variables []string
+	if ev != nil {
+		for k, v := range ev {
+			variables = append(variables, k+"="+v.(string))
+		}
+	}
+	return variables
+}
+
+func parseJSON(b []byte) (map[string]string, error) {
+	tb := bytes.Trim(b, "\x00")
+	s := string(tb)
+	var f map[string]interface{}
+	err := json.Unmarshal([]byte(s), &f)
+	output := make(map[string]string)
+	for k, v := range f {
+		output[k] = v.(string)
+	}
+	return output, err
+}
+
+func runCommand(command string, state *State, environment []string, workingDirectory string) (*State, error) {
+	const maxBufSize = 8 * 1024
+	// Execute the command using a shell
+	var shell, flag string
+	if runtime.GOOS == "windows" {
+		shell = "cmd"
+		flag = "/C"
+	} else {
+		shell = "/bin/sh"
+		flag = "-c"
+	}
+
+	// Setup the command
+	command = fmt.Sprintf("cd %s && %s", workingDirectory, command)
+	cmd := exec.Command(shell, flag, command)
+	input, _ := json.Marshal(state)
+	stdin := bytes.NewReader(input)
+	cmd.Stdin = stdin
+	environment = append(environment, os.Environ()...)
+	cmd.Env = environment
+	stdout, _ := circbuf.NewBuffer(maxBufSize)
+	stderr, _ := circbuf.NewBuffer(maxBufSize)
+	cmd.Stderr = io.Writer(stderr)
+	cmd.Stdout = io.Writer(stdout)
+	pr, pw, err := os.Pipe()
+	cmd.ExtraFiles = []*os.File{pw}
+
+	log.Printf("[DEBUG] shell script command old state: \"%v\"", state)
+
+	// Output what we're about to run
+	log.Printf("[DEBUG] shell script going to execute: %s %s \"%s\"", shell, flag, command)
+
+	// Run the command to completion
+	err = cmd.Run()
+	if err != nil {
+		return nil, fmt.Errorf("Error running command: '%v'", err)
+	}
+	pw.Close()
+
+	log.Printf("[DEBUG] Command execution completed. Reading from output pipe: >&3")
+	//read back diff output from pipe
+	data := make([]byte, maxBufSize)
+	pr.Read(data)
+
+	log.Printf("[DEBUG] shell script command stdout: \"%s\"", stdout.String())
+	log.Printf("[DEBUG] shell script command stderr: \"%s\"", stderr.String())
+	log.Printf("[DEBUG] shell script command output: \"%s\"", string(data))
+
+	output, err := parseJSON(data)
+	if err != nil {
+		log.Printf("[DEBUG] Unable to unmarshall data to map[string]string: '%v'", err)
+		return nil, nil
+	}
+	newState := NewState(environment, output)
+	log.Printf("[DEBUG] shell script command new state: \"%v\"", newState)
+	return newState, nil
+}

--- a/test/scripts/delete.sh
+++ b/test/scripts/delete.sh
@@ -1,3 +1,9 @@
+#!/bin/bash
+echo "deleting..."
+echo "writing some error" >&2
+
 IN=$(cat)
-echo $IN
+echo "stdin: ${IN}" #the old state
+
+#business logic
 rm -rf ex.json

--- a/test/scripts/read.sh
+++ b/test/scripts/read.sh
@@ -1,1 +1,9 @@
-cat ex.json
+#!/bin/bash
+echo "reading.."
+echo "writing some error" >&2
+
+IN=$(cat)
+echo "stdin: ${IN}" #the old state
+
+#business logic
+cat ex.json >&3 #must write state to >&3

--- a/test/scripts/update.sh
+++ b/test/scripts/update.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-echo "creating..."
+echo "updating..."
 echo "writing some error" >&2
 
 IN=$(cat)
-echo "stdin: ${IN}" #the old state, not useful for create step since the old state was empty
+echo "stdin: ${IN}" #the old state
 
 #business logic
 /bin/cat <<END >ex.json

--- a/test/test.tf
+++ b/test/test.tf
@@ -1,6 +1,7 @@
 provider "shell" {}
 
-data "shell_script" "test" {
+//test complete data resource 
+data "shell_script" "test1" {
   lifecycle_commands {
     read = <<EOF
       echo '{"commit_id": "b8f2b8b"}' >&3
@@ -9,24 +10,86 @@ data "shell_script" "test" {
 }
 
 output "commit_id" {
-  value = "${data.shell_script.test.output["commit_id"]}"
+  value = "${data.shell_script.test1.output["commit_id"]}"
 }
-/*
-resource "shell_script" "test" {
-  lifecycle_commands {
-    create = "bash create.sh"
-    read   = "bash read.sh"
-    delete = "bash delete.sh"
-  }
 
-  working_directory = "./scripts"
+//test resource with no read or update
+resource "shell_script" "test2" {
+  lifecycle_commands {
+    create = <<EOF
+      out='{"commit_id": "b8f2b8b", "environment": "$yolo", "tags_at_commit": "sometags", "project": "someproject", "current_date": "09/10/2014", "version": "someversion"}'
+      touch test2.json
+      echo $out >> test2.json
+      cat test2.json >&3
+    EOF
+    delete = "rm -rf test2.json"
+  }
 
   environment = {
     yolo = "yolo"
   }
 }
 
-output "environment" {
-  value = "${shell_script.test.output["environment"]}"
+//test resource with no update
+resource "shell_script" "test3" {
+  lifecycle_commands {
+    create = <<EOF
+      out='{"commit_id": "b8f2b8b", "environment": "$yolo", "tags_at_commit": "sometags", "project": "someproject", "current_date": "09/10/2014", "version": "someversion"}'
+      touch test3.json
+      echo $out >> test3.json
+      cat test3.json >&3
+    EOF
+    read   = "cat test3.json >&3"
+    delete = "rm -rf test3.json"
+  }
+
+  environment = {
+    yolo = "yolo2"
+
+  }
 }
-*/
+
+//test resource with no read
+resource "shell_script" "test4" {
+  lifecycle_commands {
+    create = <<EOF
+      out='{"commit_id": "b8f2b8b", "environment": "$yolo", "tags_at_commit": "sometags", "project": "someproject", "current_date": "09/10/2014", "version": "someversion"}'
+      touch test4.json
+      echo $out >> test4.json
+      cat test4.json >&3
+    EOF
+    update = <<EOF
+      rm -rf test4.json
+      out='{"commit_id": "b8f2b8b", "environment": "$yolo", "tags_at_commit": "sometags", "project": "someproject", "current_date": "09/10/2014", "version": "someversion"}'
+      touch test4.json
+      echo $out >> test4.json
+      cat test4.json >&3
+    EOF
+    delete = "rm -rf test4.json"
+  }
+
+  environment = {
+    yolo = "yolo"
+  }
+}
+
+//test complete resource
+resource "shell_script" "test5" {
+  lifecycle_commands {
+    create = "${file("${path.module}/scripts/create.sh")}"
+    read   = "${file("${path.module}/scripts/read.sh")}"
+    update = "${file("${path.module}/scripts/update.sh")}"
+    delete = "${file("${path.module}/scripts/delete.sh")}"
+  }
+
+  working_directory = "${path.module}"
+
+  environment = {
+    yolo = "yolo2"
+    ball = "room"
+  }
+}
+
+output "commit_id2" {
+  value = "${shell_script.test5.output["commit_id"]}"
+}

--- a/test/test.tf
+++ b/test/test.tf
@@ -3,7 +3,7 @@ provider "shell" {}
 data "shell_script" "test" {
   lifecycle_commands {
     read = <<EOF
-      echo '{"commit_id": "b8f2b8b"}'
+      echo '{"commit_id": "b8f2b8b"}' >&3
     EOF
   }
 }
@@ -11,7 +11,7 @@ data "shell_script" "test" {
 output "commit_id" {
   value = "${data.shell_script.test.output["commit_id"]}"
 }
-
+/*
 resource "shell_script" "test" {
   lifecycle_commands {
     create = "bash create.sh"
@@ -29,3 +29,4 @@ resource "shell_script" "test" {
 output "environment" {
   value = "${shell_script.test.output["environment"]}"
 }
+*/


### PR DESCRIPTION
In response to @nhoughto concerns in issue #1 , I have added support for update and made some various other small improvements

Key features;

- there is now an update lifecycle command for the shell script resource. It is optional, if you choose not to implement it then your resource will simply be destroyed and recreated when an event would occur to update the resource. Changes to environment variables or the output attribute will trigger an update.
- removed stdout and stderr as outputs of both resources. they are still available in the logs, but all state management is done through the output and environment attributes now. In order to output state from the commands, it is necessary to output to >&3. This has a side effect of removing the need to output many things to > /dev/null as was previously the case and was very confusing.
- added more test cases for each possible configuration of the resources
- updated README.md
- improved logging and error handling
- generally cleaned up and organized code a bit better