### PR TITLE
add stack tracing and dirty for marking updates

### DIFF
--- a/shell/data_source_shell_script.go
+++ b/shell/data_source_shell_script.go
@@ -1,7 +1,6 @@
 package shell
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -72,7 +71,9 @@ func dataSourceShellScriptRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if newState == nil {
-		return fmt.Errorf("Error: state from read operation cannot be nil")
+		log.Printf("[DEBUG] State from read operation was nil. Marking resource for deletion.")
+		d.SetId("")
+		return nil
 	}
 	d.Set("output", newState.output)
 

--- a/shell/resource_shell_script.go
+++ b/shell/resource_shell_script.go
@@ -1,8 +1,8 @@
 package shell
 
 import (
-	"fmt"
 	"log"
+	"reflect"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/rs/xid"
@@ -61,19 +61,42 @@ func resourceShellScript() *schema.Resource {
 				Computed: true,
 				Elem:     schema.TypeString,
 			},
+			"dirty": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 	}
 }
 
+//helpers to unwravel the recursive bits by adding a base condition
 func resourceShellScriptCreate(d *schema.ResourceData, meta interface{}) error {
+	return create(d, meta, []string{"create"})
+}
+
+func resourceShellScriptRead(d *schema.ResourceData, meta interface{}) error {
+	return read(d, meta, []string{"read"})
+}
+
+func resourceShellScriptUpdate(d *schema.ResourceData, meta interface{}) error {
+	return update(d, meta, []string{"update"})
+}
+
+func resourceShellScriptDelete(d *schema.ResourceData, meta interface{}) error {
+	return delete(d, meta, []string{"delete"})
+}
+
+func create(d *schema.ResourceData, meta interface{}, stack []string) error {
 	log.Printf("[DEBUG] Creating shell script resource...")
+	printStackTrace(stack)
 	l := d.Get("lifecycle_commands").([]interface{})
 	c := l[0].(map[string]interface{})
 	command := c["create"].(string)
 	vars := d.Get("environment").(map[string]interface{})
 	environment := readEnvironmentVariables(vars)
 	workingDirectory := d.Get("working_directory").(string)
-
+	d.MarkNewResource()
 	//obtain exclusive lock
 	shellMutexKV.Lock(shellScriptMutexKey)
 
@@ -87,7 +110,8 @@ func resourceShellScriptCreate(d *schema.ResourceData, meta interface{}) error {
 
 	//if create doesn't return a new state then must call the read operation
 	if newState == nil {
-		if err := resourceShellScriptRead(d, meta); err != nil {
+		stack = append(stack, "read")
+		if err := read(d, meta, stack); err != nil {
 			return err
 		}
 	} else {
@@ -100,8 +124,9 @@ func resourceShellScriptCreate(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceShellScriptRead(d *schema.ResourceData, meta interface{}) error {
+func read(d *schema.ResourceData, meta interface{}, stack []string) error {
 	log.Printf("[DEBUG] Reading shell script resource...")
+	printStackTrace(stack)
 	l := d.Get("lifecycle_commands").([]interface{})
 	c := l[0].(map[string]interface{})
 	command := c["read"].(string)
@@ -122,7 +147,6 @@ func resourceShellScriptRead(d *schema.ResourceData, meta interface{}) error {
 
 	//obtain exclusive lock
 	shellMutexKV.Lock(shellScriptMutexKey)
-	defer shellMutexKV.Unlock(shellScriptMutexKey)
 
 	state := NewState(environment, output)
 	newState, err := runCommand(command, state, environment, workingDirectory)
@@ -130,33 +154,54 @@ func resourceShellScriptRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	shellMutexKV.Unlock(shellScriptMutexKey)
 	if newState == nil {
-		return fmt.Errorf("Error: state from read operation cannot be nil")
+		log.Printf("[DEBUG] State from read operation was nil. Marking resource for deletion.")
+		d.SetId("")
+	} else {
+		log.Printf("[DEBUG] output:|%v|", output)
+		log.Printf("[DEBUG] new output:|%v|", newState.output)
+		isStateEqual := reflect.DeepEqual(output, newState.output)
+		isNewResource := d.IsNewResource()
+		isUpdatedResource := stack[0] == "update"
+		if !isStateEqual && !isNewResource && !isUpdatedResource {
+			log.Printf("[DEBUG] Previous state not equal to new state. Marking resource as dirty to trigger update.")
+			d.Set("dirty", true)
+			return nil
+		}
+
 	}
 	d.Set("output", newState.output)
+
 	return nil
 }
 
-func resourceShellScriptUpdate(d *schema.ResourceData, meta interface{}) error {
+func update(d *schema.ResourceData, meta interface{}, stack []string) error {
 	log.Printf("[DEBUG] Updating shell script resource...")
+	d.Set("dirty", false)
+	printStackTrace(stack)
 	l := d.Get("lifecycle_commands").([]interface{})
 	c := l[0].(map[string]interface{})
 	command := c["update"].(string)
 
 	//if update is not set, then treat it simply as a tainted resource - delete then recreate
 	if len(command) == 0 {
-		resourceShellScriptDelete(d, meta)
-		return resourceShellScriptCreate(d, meta)
+		stack = append(stack, "delete")
+		delete(d, meta, stack)
+		stack = append(stack, "create")
+		return create(d, meta, stack)
 	}
 
-	//need to get the old environment
-	var vars map[string]interface{}
+	//need to get the old environment if it exists
+	oldVars := make(map[string]interface{})
 	if d.HasChange("environment") {
 		e, _ := d.GetChange("environment")
-		vars = e.(map[string]interface{})
+		oldVars = e.(map[string]interface{})
 	}
-
+	oldEnvironment := readEnvironmentVariables(oldVars)
+	vars := d.Get("environment").(map[string]interface{})
 	environment := readEnvironmentVariables(vars)
+
 	workingDirectory := d.Get("working_directory").(string)
 	o := d.Get("output").(map[string]interface{})
 	output := make(map[string]string)
@@ -167,7 +212,7 @@ func resourceShellScriptUpdate(d *schema.ResourceData, meta interface{}) error {
 	//obtain exclusive lock
 	shellMutexKV.Lock(shellScriptMutexKey)
 
-	state := NewState(environment, output)
+	state := NewState(oldEnvironment, output)
 	newState, err := runCommand(command, state, environment, workingDirectory)
 	if err != nil {
 		return err
@@ -177,7 +222,8 @@ func resourceShellScriptUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	//if update doesn't return a new state then must call the read operation
 	if newState == nil {
-		if err := resourceShellScriptRead(d, meta); err != nil {
+		stack = append(stack, "read")
+		if err := read(d, meta, stack); err != nil {
 			return err
 		}
 	} else {
@@ -186,8 +232,9 @@ func resourceShellScriptUpdate(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceShellScriptDelete(d *schema.ResourceData, meta interface{}) error {
+func delete(d *schema.ResourceData, meta interface{}, stack []string) error {
 	log.Printf("[DEBUG] Deleting shell script resource...")
+	printStackTrace(stack)
 	l := d.Get("lifecycle_commands").([]interface{})
 	c := l[0].(map[string]interface{})
 	command := c["delete"].(string)

--- a/shell/utility.go
+++ b/shell/utility.go
@@ -34,6 +34,15 @@ func readEnvironmentVariables(ev map[string]interface{}) []string {
 	return variables
 }
 
+func printStackTrace(stack []string) {
+	log.Printf("-------------------------")
+	log.Printf("[DEBUG] Current stack:")
+	for _, v := range stack {
+		log.Printf("[DEBUG] -- %s", v)
+	}
+	log.Printf("-------------------------")
+}
+
 func parseJSON(b []byte) (map[string]string, error) {
 	tb := bytes.Trim(b, "\x00")
 	s := string(tb)

--- a/test/test.tf
+++ b/test/test.tf
@@ -1,5 +1,5 @@
 provider "shell" {}
-
+/*
 //test complete data resource 
 data "shell_script" "test1" {
   lifecycle_commands {
@@ -72,7 +72,7 @@ resource "shell_script" "test4" {
     yolo = "yolo"
   }
 }
-
+*/
 //test complete resource
 resource "shell_script" "test5" {
   lifecycle_commands {
@@ -85,7 +85,7 @@ resource "shell_script" "test5" {
   working_directory = "${path.module}"
 
   environment = {
-    yolo = "yolo2"
+    yolo = "yolo"
     ball = "room"
   }
 }


### PR DESCRIPTION
Minor polishing things and some bug fixes. Update previously did not track changes to state correctly. Now if there is a change to the state, it will change the internal bool dirty to true, which will force an update. Dirty can also be used by the user to force an update, although this isn't recommended.

Features:
* Improved stack tracing for understanding when each operation is taking place, and what steps happened before. This aids a lot in debugging.
* Update now correctly receives the old environment variables in the stdin
* New attribute, "dirty" which is used to force an update when the state has changed
