### PR TITLE
Feature/bug fix

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform/plugin"
-	"githubdev.dco.elmae/CloudPlatform/terraform-provider-shell/shell"
+	"github.com/scottwinkler/terraform-provider-shell/shell"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/scottwinkler/terraform-provider-shell/shell"
+	"githubdev.dco.elmae/CloudPlatform/terraform-provider-shell/shell"
 )
 
 func main() {

--- a/shell/data_source_shell_script.go
+++ b/shell/data_source_shell_script.go
@@ -75,7 +75,7 @@ func dataSourceShellScriptRead(d *schema.ResourceData, meta interface{}) error {
 		d.SetId("")
 		return nil
 	}
-	d.Set("output", newState.output)
+	d.Set("output", newState.Output)
 
 	//create random uuid for the id
 	id := xid.New().String()

--- a/shell/resource_shell_script.go
+++ b/shell/resource_shell_script.go
@@ -115,7 +115,7 @@ func create(d *schema.ResourceData, meta interface{}, stack []string) error {
 			return err
 		}
 	} else {
-		d.Set("output", newState.output)
+		d.Set("output", newState.Output)
 	}
 
 	//create random uuid for the id
@@ -158,20 +158,20 @@ func read(d *schema.ResourceData, meta interface{}, stack []string) error {
 	if newState == nil {
 		log.Printf("[DEBUG] State from read operation was nil. Marking resource for deletion.")
 		d.SetId("")
-	} else {
-		log.Printf("[DEBUG] output:|%v|", output)
-		log.Printf("[DEBUG] new output:|%v|", newState.output)
-		isStateEqual := reflect.DeepEqual(output, newState.output)
-		isNewResource := d.IsNewResource()
-		isUpdatedResource := stack[0] == "update"
-		if !isStateEqual && !isNewResource && !isUpdatedResource {
-			log.Printf("[DEBUG] Previous state not equal to new state. Marking resource as dirty to trigger update.")
-			d.Set("dirty", true)
-			return nil
-		}
-
+		return nil
 	}
-	d.Set("output", newState.output)
+	log.Printf("[DEBUG] output:|%v|", output)
+	log.Printf("[DEBUG] new output:|%v|", newState.Output)
+	isStateEqual := reflect.DeepEqual(output, newState.Output)
+	isNewResource := d.IsNewResource()
+	isUpdatedResource := stack[0] == "update"
+	if !isStateEqual && !isNewResource && !isUpdatedResource {
+		log.Printf("[DEBUG] Previous state not equal to new state. Marking resource as dirty to trigger update.")
+		d.Set("dirty", true)
+		return nil
+	}
+
+	d.Set("output", newState.Output)
 
 	return nil
 }
@@ -227,7 +227,7 @@ func update(d *schema.ResourceData, meta interface{}, stack []string) error {
 			return err
 		}
 	} else {
-		d.Set("output", newState.output)
+		d.Set("output", newState.Output)
 	}
 	return nil
 }

--- a/test/scripts/create.sh
+++ b/test/scripts/create.sh
@@ -9,4 +9,4 @@ echo "stdin: ${IN}" #the old state, not useful for create step since the old sta
 /bin/cat <<END >ex.json
   {"commit_id": "b8f2b8b", "environment": "$yolo", "tags_at_commit": "sometags", "project": "someproject", "current_date": "09/10/2014", "version": "someversion"}
 END
-cat ex.json >&3
+cat ex.json

--- a/test/scripts/create.sh
+++ b/test/scripts/create.sh
@@ -9,3 +9,4 @@ echo "stdin: ${IN}" #the old state, not useful for create step since the old sta
 /bin/cat <<END >ex.json
   {"commit_id": "b8f2b8b", "environment": "$yolo", "tags_at_commit": "sometags", "project": "someproject", "current_date": "09/10/2014", "version": "someversion"}
 END
+cat ex.json >&3

--- a/test/test.tf
+++ b/test/test.tf
@@ -1,5 +1,5 @@
 provider "shell" {}
-/*
+
 //test complete data resource 
 data "shell_script" "test1" {
   lifecycle_commands {
@@ -72,7 +72,7 @@ resource "shell_script" "test4" {
     yolo = "yolo"
   }
 }
-*/
+
 //test complete resource
 resource "shell_script" "test5" {
   lifecycle_commands {


### PR DESCRIPTION
Minor bug fixes addressing two issues:
1) Old state was not being passed to stdin. Now the output from the read/create is passed to stdin -- environment variables can still be read as normal.
2) If the read returns a corrupted state, then it would trigger a panic when trying to set output. Now it returns nil to prevent this from happening.