### PR TITLE
Enhanced test, test handling large JSON output

### DIFF
--- a/shell/resource_shell_script_test.go
+++ b/shell/resource_shell_script_test.go
@@ -80,7 +80,7 @@ func TestAccShellShellScript_complete(t *testing.T) {
 				Config: testAccShellScriptConfig_complete(rString),
 
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "output.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "output.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "output.out1", rString),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 				),
@@ -182,6 +182,7 @@ func testAccShellScriptConfig_complete(outValue string) string {
 
 		environment = {
 			filename= "create_complete.json"
+			testdatasize = "10240"						
 			out1 = "%s"
 		}
 	  }

--- a/shell/test-fixtures/scripts/create.sh
+++ b/shell/test-fixtures/scripts/create.sh
@@ -5,9 +5,11 @@ echo "writing some error" >&2
 IN=$(cat)
 echo "stdin: ${IN}" #the old state, not useful for create step since the old state was empty
 
-#business logic
+#business logic, create a large string and write a JSON stucture to file
+TESTDATA=$(head -c $testdatasize < /dev/zero | tr '\0' '\141')
+
 /bin/cat <<END >${filename}
-  {"out1": "${out1}"}
+  {"data":"${TESTDATA}", "out1": "${out1}"}
 END
 
 cat ${filename} >&3

--- a/shell/test-fixtures/scripts/update.sh
+++ b/shell/test-fixtures/scripts/update.sh
@@ -5,7 +5,9 @@ echo "writing some error" >&2
 IN=$(cat)
 echo "stdin: ${IN}" #the old state
 
-#business logic
+#business logic, create a large string and write a JSON stucture to file
+TESTDATA=$(head -c $testdatasize < /dev/zero | tr '\0' '\141')
+
 /bin/cat <<END >${filename}
-  {"out1": "${out1}"}
+  {"data":"${TESTDATA}", "out1": "${out1}"}
 END


### PR DESCRIPTION
As suggested in the comment by @scottwinkler  on the previous pull request, I merged the test code to this branch. 
I also enhanced the test so the test scripts now generate a large (>8K) JSON structure so the read loop is tested better.