### PR TITLE
Override OS environment variables instead of vice versa

### DIFF
--- a/shell/utility.go
+++ b/shell/utility.go
@@ -73,7 +73,7 @@ func runCommand(command string, state *State, environment []string, workingDirec
 	input, _ := json.Marshal(state.Output)
 	stdin := bytes.NewReader(input)
 	cmd.Stdin = stdin
-	environment = append(environment, os.Environ()...)
+	environment = append(os.Environ(), environment...)
 	cmd.Env = environment
 	stdout, _ := circbuf.NewBuffer(maxBufSize)
 	stderr, _ := circbuf.NewBuffer(maxBufSize)


### PR DESCRIPTION
When environment variables are also set in the os environment:
```
juergen@lemmy:~/tmp/terraform-provider-shell/examples → yolo=foo terraform apply
data.shell_script.test: Refreshing state...

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:
...
  # shell_script.test6 will be created
  + resource "shell_script" "test6" {
      + dirty             = false
      + environment       = {
          + "ball" = "room"
          + "yolo" = "yolo"
    
...
```

terraform environment config has no effect:
```
juergen@lemmy:~/tmp/terraform-provider-shell/examples → terraform state show shell_script.test6
# shell_script.test6:
resource "shell_script" "test6" {
    dirty             = false
    environment       = {
        "ball" = "room"
        "yolo" = "yolo"
    }
    id                = "bn4qlgjcobsd8o2f2k4g"
    output            = {
        "commit_id"      = "b8f2b8b"
        "current_date"   = "09/10/2014"
         "environment"    = "foo"
                         ^^^^^^^^^^^^^^^
}
```

