### PR TITLE
fix: parseJSON does not crash with null output

### DIFF
--- a/shell/utility.go
+++ b/shell/utility.go
@@ -50,7 +50,11 @@ func parseJSON(b []byte) (map[string]string, error) {
 	err := json.Unmarshal([]byte(s), &f)
 	output := make(map[string]string)
 	for k, v := range f {
-		output[k] = v.(string)
+		outputString, ok := v.(string)
+		if !ok {
+			outputString = ""
+		}
+		output[k] = outputString
 	}
 	return output, err
 }


### PR DESCRIPTION
fixes issue #23 

A type assertion was added to default null output to an empty string. 
All tests are passing.

Let me know if you would like anything more.

Thanks :) 