### PR TITLE
complex JSON fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ This plugin is for wrapping shell scripts to make them fully fledged terraform r
 Get some coffee! ☕
 
 ## Examples
-There is nothing to configure for the provider, declare it like so:
+There is nothing to configure for the provider, you can declare it like so (or even omit it entirely):
 
 ```
 provider "shell" {}
 ```
-To use a data resource you need to implement the read command. Any output to stdout or stderr will show up in the logs, but to save the state, you must output a JSON payload to stdout. The last JSON object printed to stdout will be taken to be the state. The JSON shouln't be deeply nested and should be able to be marshalled into a `map[string]string`. The reason for this is that your JSON payload variables can be accessed from the output map of this resource and used like a normal terraform output, so the value must be a string.
+To use a data resource you need to implement the read command. Any output to stdout or stderr will show up in the logs, but to save the state, you must output a JSON payload to stdout. The last JSON object printed to stdout will be taken to be the state. The JSON can be a complex nested JSON, but will be flattened into a `map[string]string`. The reason for this is that your JSON payload variables can be accessed from the output map of this resource and used like a normal terraform output, so the value must be a string.
 
 ```
 data "shell_script" "user" {
@@ -102,7 +102,7 @@ A complete example that uses all four lifecycle commands is shown below:
 
 In the example I am setting the `working_directory` argument (which switches the current working directory), some environment variables that will be utilized by all my scripts, and configuring my lifecycle commands for `CREATE`, `READ`, `UPDATE` and `DELETE`. `CREATE`and `UPDATE` will modify the resource but not update the state, while `READ` updates the state but does not modify the resource.
 
-An example shell script resouce could have a file being written to in the `CREATE`. `READ` would simply cat that previously created file and output it to `>&3`. `UPDATE` could measure the changes from the old state (available through stdin) and the new state (available through environment variables) to decide how best to handle an update. Again since this is a custom resource it is up to you to decide how best to handle updates, in many cases it may make sense not to implement `UPDATE` at all and rely on just `CREATE`/`READ`/`DELETE`.
+An example shell script resouce could have a file being written to in the `CREATE`. `READ` would simply cat that previously created file and output it to stdout. `UPDATE` could measure the changes from the old state (available through stdin) and the new state (available through environment variables) to decide how best to handle an update. Again since this is a custom resource it is up to you to decide how best to handle updates, in many cases it may make sense not to implement `UPDATE` at all and rely on just `CREATE`/`READ`/`DELETE`.
 
 `DELETE` needs to clean up any resources that were created but does not need to return anything. State data is available in the `output` variable, which is mapped from the JSON of your read command.
 

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/ryanuber/columnize v2.1.0+incompatible // indirect
 	github.com/terraform-providers/terraform-provider-aws v1.60.0 // indirect
 	github.com/terraform-providers/terraform-provider-openstack v1.26.0 // indirect
+	github.com/tidwall/gjson v1.6.0
 	github.com/xanzy/ssh-agent v0.2.1 // indirect
 	github.com/xlab/treeprint v1.0.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -776,6 +776,7 @@ github.com/hashicorp/terraform-plugin-sdk v1.0.0/go.mod h1:NuwtLpEpPsFaKJPJNGtMc
 github.com/hashicorp/terraform-plugin-sdk v1.1.1 h1:wQ2HtvOE8K4QYcm2JB8YFw9u7OplFJ2HMV5WOpMRL2Y=
 github.com/hashicorp/terraform-plugin-sdk v1.7.0 h1:B//oq0ZORG+EkVrIJy0uPGSonvmXqxSzXe8+GhknoW0=
 github.com/hashicorp/terraform-plugin-sdk v1.7.0/go.mod h1:OjgQmey5VxnPej/buEhe+YqKm0KNvV3QqU4hkqHqPCY=
+github.com/hashicorp/terraform-plugin-sdk v1.8.0 h1:HE1p52nzcgz88hIJmapUnkmM9noEjV3QhTOLaua5XUA=
 github.com/hashicorp/terraform-plugin-test v1.2.0 h1:AWFdqyfnOj04sxTdaAF57QqvW7XXrT8PseUHkbKsE8I=
 github.com/hashicorp/terraform-plugin-test v1.2.0/go.mod h1:QIJHYz8j+xJtdtLrFTlzQVC0ocr3rf/OjIpgZLK56Hs=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596 h1:hjyO2JsNZUKT1ym+FAdlBEkGPevazYsmVgIMw7dVELg=
@@ -1164,6 +1165,12 @@ github.com/terraform-providers/terraform-provider-openstack v1.26.0 h1:j+6EVPmd2
 github.com/terraform-providers/terraform-provider-openstack v1.26.0/go.mod h1:f5nbXTxcTPwupICte52bhqBQWUZUf34iYtRROAf4RUY=
 github.com/terraform-providers/terraform-provider-template v0.1.1/go.mod h1:/J+B8me5DCMa0rEBH5ic2aKPjhtpWNeScmxFJWxB1EU=
 github.com/terraform-providers/terraform-provider-tls v0.1.0/go.mod h1:Mxe/v5u31LDW4m32O1z6Ursdh95dpc9Puq6otkYg7tU=
+github.com/tidwall/gjson v1.6.0 h1:9VEQWz6LLMUsUl6PueE49ir4Ka6CzLymOAZDxpFsTDc=
+github.com/tidwall/gjson v1.6.0/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
+github.com/tidwall/match v1.0.1 h1:PnKP62LPNxHKTwvHHZZzdOAOCtsJTjo6dZLCwpKm5xc=
+github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
+github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
+github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tinylib/msgp v1.1.0/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tj/go-elastic v0.0.0-20171221160941-36157cbbebc2/go.mod h1:WjeM0Oo1eNAjXGDx2yma7uG2XoyRZTq1uv3M/o7imD0=
 github.com/tj/go-kinesis v0.0.0-20171128231115-08b17f58cb1b/go.mod h1:/yhzCV0xPfx6jb1bBgRFjl5lytqVqZXEaeqWP8lTEao=

--- a/shell/utility.go
+++ b/shell/utility.go
@@ -149,21 +149,18 @@ func parseJSON(s string) (map[string]string, error) {
 	result := gjson.Parse(s)
 	result.ForEach(func(key, value gjson.Result) bool {
 		output[key.String()] = value.String()
-		return true // keep iterating
+		return true
 	})
 	return output, nil
 }
 
 func getOutputMap(s string) map[string]string {
-	//Find all matches of "{(.*)" in output
-	fmt.Printf("[DEBUG] s: %v\n", s)
+	//Find all matches of "{(.*)/g" in output
 	var matches []string
 	substring := s
 	idx := strings.Index(substring, "{")
 	for idx != -1 {
 		substring = substring[idx:]
-		fmt.Printf("[DEBUG] idx: %d\n", idx)
-		fmt.Printf("[DEBUG] substring: %s\n", substring)
 		matches = append(matches, substring)
 		if len(substring) > 0 {
 			substring = substring[1:]
@@ -171,12 +168,11 @@ func getOutputMap(s string) map[string]string {
 		idx = strings.Index(substring, "{")
 	}
 
-	//Find last match
+	//Use last match that is a valid JSON
 	var m map[string]string
 	var err error
 	for i := range matches {
 		match := matches[len(matches)-1-i]
-		log.Printf("[DEBUG] match: %s", match)
 		m, err = parseJSON(match)
 		if err == nil {
 			//match found


### PR DESCRIPTION
Fixes tickets #31 and #32. 

This fixes the way JSON is parsed from the output to allow support for more complex JSON strings. Previously only JSON that matched exactly a map[string]string could be returned from a shell_script resource. Now any JSON can be returned It will still be converted to a map[string]string and any complex values will be flattened. For example, the following JSON would return the following output:

```
{
  "last_state_loss_time": 0,
  "spark_version": "5.3.x-scala2.11",
  "azure_attributes": {},
  "state": "PENDING",
  "enable_elastic_disk": true,
  "init_scripts_safe_mode": false,
  "num_workers": 1,
  "driver_node_type_id": "Standard_D3_v2",
  "default_tags": {
    "Creator": "lagripp@microsoft.com",
    "ClusterName": "my-cluster",
    "ClusterId": "0327-174802-howdy690",
    "Vendor": "Databricks"
  },
  "creator_user_name": "lagripp@microsoft.com",
  "cluster_id": "0327-174802-howdy690",
  "cluster_name": "my-cluster",
  "node_type_id": "Standard_D3_v2",
  "state_message": "Finding instances for new nodes, acquiring more instances if necessary",
  "enable_local_disk_encryption": false,
  "autotermination_minutes": 0,
  "cluster_source": "API",
  "start_time": 1585331282783,
  "spark_conf": {
    "spark.speculation": "true"
  }
```

```
            "output": {
              "autotermination_minutes": "0",
              "azure_attributes": "{}",
              "cluster_id": "0327-174802-howdy690",
              "cluster_name": "my-cluster",
              "cluster_source": "API",
              "creator_user_name": "lagripp@microsoft.com",
              "default_tags": "{    \"Creator\": \"lagripp@microsoft.com\",    \"ClusterName\": \"my-cluster\",    \"ClusterId\": \"0327-174802-howdy690\",    \"Vendor\": \"Databricks\"  }",
              "driver_node_type_id": "Standard_D3_v2",
              "enable_elastic_disk": "true",
              "enable_local_disk_encryption": "false",
              "init_scripts_safe_mode": "false",
              "last_state_loss_time": "0",
              "node_type_id": "Standard_D3_v2",
              "num_workers": "1",
              "spark_conf": "{    \"spark.speculation\": \"true\"  }",
              "spark_version": "5.3.x-scala2.11",
              "start_time": "1585331282783",
              "state": "PENDING",
              "state_message": "Finding instances for new nodes, acquiring more instances if necessary"
            },
```
