### PR TITLE
Added sensitive environment variables block

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,32 @@ Stdout and stderr are also available in the debug log files. You can get this by
 export TF_LOG=debug
 ```
 
+## Sensitive environment variables
+Environment variables will be displayed in the plan by terraform. If you don't want them to show up in your terminal, use `environment_sensitive` instead of `environment`. You can also use both:
+
+	resource "shell_script" "test" {
+		lifecycle_commands {
+			create = file("${path.module}/scripts/create.sh")
+			read   = file("${path.module}/scripts/read.sh")
+			update = file("${path.module}/scripts/update.sh")
+			delete = file("${path.module}/scripts/delete.sh")
+		}
+
+		working_directory = path.module
+
+		environment = {
+			yolo = "yolo"
+			ball = "room"
+		}
+
+		environment_sensitive = {
+			yolo = "replaced"
+			animal = "dragon"
+		}
+	}
+
+In this case, the definitive variables will be `ball=room`, `animal=dragon` and `yolo=replaced`, because sensitive variables will replace normal ones.
+
 ## Python and Golang Support
 There is now an example for how to use the shell provider to invoke python and golang files. Please check in the `examples/python-adapter` and `examples/golang-adapter` folder for more information on this. Essentially it is an adapter around the `shell_resource` that invokes methods on an interface that you implement.
 

--- a/examples/test/test.tf
+++ b/examples/test/test.tf
@@ -114,3 +114,27 @@ resource "shell_script" "test6" {
     abc = 123
   }
 }
+
+//sensitive environment variables
+resource "shell_script" "test8" {
+  lifecycle_commands {
+    create = file("${path.module}/scripts/create.sh")
+    read   = file("${path.module}/scripts/read.sh")
+    update = file("${path.module}/scripts/update.sh")
+    delete = file("${path.module}/scripts/delete.sh")
+  }
+
+  working_directory = "${path.module}"
+
+  environment = {
+    yolo = "yolo"
+  }
+
+  environment_sensitive = {
+    yolo = "yolo_replaced"
+  }
+}
+
+output "test8_environment" {
+  value = shell_script.test8.output["environment"] # should be "yolo_replaced"
+}

--- a/shell/data_source_shell_script.go
+++ b/shell/data_source_shell_script.go
@@ -33,6 +33,13 @@ func dataSourceShellScript() *schema.Resource {
 				ForceNew: true,
 				Elem:     schema.TypeString,
 			},
+			"environment_sensitive": {
+				Type:      schema.TypeMap,
+				Optional:  true,
+				ForceNew:  true,
+				Elem:      schema.TypeString,
+				Sensitive: true,
+			},
 			"working_directory": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -56,7 +63,9 @@ func dataSourceShellScriptRead(d *schema.ResourceData, meta interface{}) error {
 
 	command := value.(string)
 	vars := d.Get("environment").(map[string]interface{})
-	environment := readEnvironmentVariables(vars)
+	varsSensitive := d.Get("environment_sensitive").(map[string]interface{})
+	varsAll := mergeEnvironmentMaps(vars, varsSensitive)
+	environment := readEnvironmentVariables(varsAll)
 	workingDirectory := d.Get("working_directory").(string)
 	output := make(map[string]string)
 

--- a/shell/data_source_shell_script_test.go
+++ b/shell/data_source_shell_script_test.go
@@ -17,8 +17,11 @@ func TestAccShellDataShellScript_basic(t *testing.T) {
 			{
 				Config: testAccDataShellScriptConfig(rString),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "output.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "output.%", "4"),
 					resource.TestCheckResourceAttr(resourceName, "output.out1", rString),
+					resource.TestCheckResourceAttr(resourceName, "output.out2", rString),
+					resource.TestCheckResourceAttr(resourceName, "output.out3", rString),
+					resource.TestCheckResourceAttr(resourceName, "output.out4", rString),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 				),
 			},
@@ -31,9 +34,20 @@ func testAccDataShellScriptConfig(outValue string) string {
 	data "shell_script" "test" {
 	  lifecycle_commands {
 		read = <<EOF
-		  echo '{"out1": "%s"}'
+		  echo '{"out1": "'$OUTVALUE1'", "out2": "'$OUTVALUE2'", "out3": "'$OUTVALUE3'", "out4": "%s"}'
 EOF
 	  }
+
+	  environment = {
+		OUTVALUE1 = "%s"
+		OUTVALUE3 = "will be replaced"
+	  }
+
+	  environment_sensitive = {
+		OUTVALUE2 = "%s"
+		OUTVALUE3 = "%s"
+	  }
 	}
-`, outValue)
+`, outValue, outValue, outValue, outValue)
 }
+

--- a/shell/utility.go
+++ b/shell/utility.go
@@ -28,7 +28,12 @@ func NewState(environment []string, output map[string]string) *State {
 
 // in case of duplicates, ev2 will overwrite ev1 entries
 func mergeEnvironmentMaps(ev1 map[string]interface{}, ev2 map[string]interface{}) map[string]interface{} {
-    res := ev1
+	res := make(map[string]interface{})
+	if ev1 != nil {
+		for k, v := range ev1 {
+			res[k] = v
+		}
+	}
     if ev2 != nil {
 		for k, v := range ev2 {
 			res[k] = v

--- a/shell/utility.go
+++ b/shell/utility.go
@@ -26,6 +26,17 @@ func NewState(environment []string, output map[string]string) *State {
 	return &State{Environment: environment, Output: output}
 }
 
+// in case of duplicates, ev2 will overwrite ev1 entries
+func mergeEnvironmentMaps(ev1 map[string]interface{}, ev2 map[string]interface{}) map[string]interface{} {
+    res := ev1
+    if ev2 != nil {
+		for k, v := range ev2 {
+			res[k] = v
+		}
+	}
+    return res
+}
+
 func readEnvironmentVariables(ev map[string]interface{}) []string {
 	var variables []string
 	if ev != nil {


### PR DESCRIPTION
Pretty useful if you don't want your environment variables to be displayed when terraform outputs the plan (eg tokens, passwords, etc).

Added documentation in README, example and tests. (Couldn't add another data_source test because of some race condition coming from the schema functions, it doesn't seem to be related to my code.)