### PR TITLE
throw error on delete

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,6 +1,6 @@
 TEST?=$$(go list ./... |grep -v 'vendor')
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
-PKG_NAME=minecraft
+PKG_NAME=shell
 
 default: build
 

--- a/shell/resource_shell_script.go
+++ b/shell/resource_shell_script.go
@@ -242,8 +242,10 @@ func delete(d *schema.ResourceData, meta interface{}, stack []string) error {
 	}
 
 	state := NewState(environment, output)
-	runCommand(command, state, environment, workingDirectory)
-
+	_, err := runCommand(command, state, environment, workingDirectory)
+	if err != nil {
+		return err
+	}
 	d.SetId("")
 	return nil
 }


### PR DESCRIPTION
Closes issue #40 

Originally the `delete()` method did not throw errors because `runCommand() ` did not return anything sensible as far as errors were concerned (it would throw errors if no state was found, which doesn't really impact the result of the delete, because the resource is being deleted anyways). Now that `runCommand()` throws errors only when the scripts returns a non zero error condition, it makes sense for `delete()` to throw that error, like `create()`, `update()`, and `read()` do. Yes, this could cause an awkward condition where you have an error in the `delete()` script and cannot update it because the `delete()` keeps failing, but that is a small inconvenience. Generally, users will want to know if a script is returning non-zero error condition and if this means the resource must be manually removed from the state file to proceed, that is an acceptable outcome.

For the following resource:
```
resource "shell_script" "ex" {
  lifecycle_commands {
    create = ""
    delete = "exit 1"
  }
}
```

The following error will be thrown:

```
w10jbiglx1:tmp swinkler$ terraform destroy -force
shell_script.ex: Refreshing state... [id=bqao2mtgrkrksr291p0g]
shell_script.ex: Destroying... [id=bqao2mtgrkrksr291p0g]

Error: Error occured in Command: 'exit 1' Error: 'exit status 1'
 StdOut:

 StdErr:
```