### PR TITLE
add sensitive env block

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -777,6 +777,7 @@ github.com/hashicorp/terraform-plugin-sdk v1.1.1 h1:wQ2HtvOE8K4QYcm2JB8YFw9u7Opl
 github.com/hashicorp/terraform-plugin-sdk v1.7.0 h1:B//oq0ZORG+EkVrIJy0uPGSonvmXqxSzXe8+GhknoW0=
 github.com/hashicorp/terraform-plugin-sdk v1.7.0/go.mod h1:OjgQmey5VxnPej/buEhe+YqKm0KNvV3QqU4hkqHqPCY=
 github.com/hashicorp/terraform-plugin-sdk v1.8.0 h1:HE1p52nzcgz88hIJmapUnkmM9noEjV3QhTOLaua5XUA=
+github.com/hashicorp/terraform-plugin-sdk v1.9.1 h1:AgHnd6yPCg7o57XWrv4L7tIMdF0KQpcZro1pDHF1Xbw=
 github.com/hashicorp/terraform-plugin-test v1.2.0 h1:AWFdqyfnOj04sxTdaAF57QqvW7XXrT8PseUHkbKsE8I=
 github.com/hashicorp/terraform-plugin-test v1.2.0/go.mod h1:QIJHYz8j+xJtdtLrFTlzQVC0ocr3rf/OjIpgZLK56Hs=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596 h1:hjyO2JsNZUKT1ym+FAdlBEkGPevazYsmVgIMw7dVELg=

--- a/shell/data_source_shell_script.go
+++ b/shell/data_source_shell_script.go
@@ -33,6 +33,12 @@ func dataSourceShellScript() *schema.Resource {
 				ForceNew: true,
 				Elem:     schema.TypeString,
 			},
+			"sensitive_environment": {
+				Type:      schema.TypeMap,
+				Optional:  true,
+				Elem:      schema.TypeString,
+				Sensitive: true,
+			},
 			"working_directory": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -55,13 +61,13 @@ func dataSourceShellScriptRead(d *schema.ResourceData, meta interface{}) error {
 	value := c["read"]
 
 	command := value.(string)
-	vars := d.Get("environment").(map[string]interface{})
-	environment := readEnvironmentVariables(vars)
+	environment := packEnvironmentVariables(d.Get("environment"))
+	sensitiveEnvironment := packEnvironmentVariables(d.Get("sensitive_environment"))
 	workingDirectory := d.Get("working_directory").(string)
 	output := make(map[string]string)
 
-	state := NewState(environment, output)
-	newState, err := runCommand(command, state, environment, workingDirectory)
+	state := NewState(environment, sensitiveEnvironment, output)
+	newState, err := runCommand(command, state, workingDirectory)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This closes issue #22 and pull request #38 .

A new optional block is added to both the shell_script data source and managed resource. This block, called `sensitive_environment` functions exactly the same as `environment`, except it is marked as sensitive and any variables in the map will not be printed to the console (both in DEBUG and non DEBUG). All sensitive values are replaced with "******" if they would have otherwise been printed. This makes the provider work better with secrets that you don't want in the state file or leaked in the plan.

Consider the following code snippet:
```
data "shell_script" "print_credentials" {
  lifecycle_commands {
    read = "echo $AWS_SECRET_ACCESS_KEY"
  }
  sensitive_environment = {
      AWS_SECRET_ACCESS_KEY = "secret_value"
  }
}
```

If this were to be applied, the following would appear in the logs:

```
data.shell_script.print_credentials: Refreshing state...
2020-04-14T03:59:47.760-0700 [DEBUG] plugin.terraform-provider-shell_v1.2.0: 2020/04/14 03:59:47 [DEBUG] Reading shell script data resource...
2020-04-14T03:59:47.760-0700 [DEBUG] plugin.terraform-provider-shell_v1.2.0: 2020/04/14 03:59:47 [DEBUG] Locking "shellScriptMutexKey"
2020-04-14T03:59:47.760-0700 [DEBUG] plugin.terraform-provider-shell_v1.2.0: 2020/04/14 03:59:47 [DEBUG] Locked "shellScriptMutexKey"
2020-04-14T03:59:47.760-0700 [DEBUG] plugin.terraform-provider-shell_v1.2.0: 2020/04/14 03:59:47 [DEBUG] shell script going to execute: /bin/sh -c
2020-04-14T03:59:47.760-0700 [DEBUG] plugin.terraform-provider-shell_v1.2.0: 2020/04/14 03:59:47    echo $AWS_SECRET_ACCESS_KEY
2020-04-14T03:59:47.760-0700 [DEBUG] plugin.terraform-provider-shell_v1.2.0: 2020/04/14 03:59:47 -------------------------
2020-04-14T03:59:47.760-0700 [DEBUG] plugin.terraform-provider-shell_v1.2.0: 2020/04/14 03:59:47 [DEBUG] Starting execution...
2020-04-14T03:59:47.760-0700 [DEBUG] plugin.terraform-provider-shell_v1.2.0: 2020/04/14 03:59:47 -------------------------
2020-04-14T03:59:47.765-0700 [DEBUG] plugin.terraform-provider-shell_v1.2.0: 2020/04/14 03:59:47   ******
2020-04-14T03:59:47.765-0700 [DEBUG] plugin.terraform-provider-shell_v1.2.0: 2020/04/14 03:59:47 -------------------------
2020-04-14T03:59:47.765-0700 [DEBUG] plugin.terraform-provider-shell_v1.2.0: 2020/04/14 03:59:47 [DEBUG] Command execution completed:
2020-04-14T03:59:47.765-0700 [DEBUG] plugin.terraform-provider-shell_v1.2.0: 2020/04/14 03:59:47 -------------------------
2020-04-14T03:59:47.765-0700 [DEBUG] plugin.terraform-provider-shell_v1.2.0: 2020/04/14 03:59:47 [DEBUG] no valid JSON strings found at end of output:
2020-04-14T03:59:47.765-0700 [DEBUG] plugin.terraform-provider-shell_v1.2.0: ******
2020-04-14T03:59:47.765-0700 [DEBUG] plugin.terraform-provider-shell_v1.2.0: 2020/04/14 03:59:47 [DEBUG] Unlocking "shellScriptMutexKey"
2020-04-14T03:59:47.765-0700 [DEBUG] plugin.terraform-provider-shell_v1.2.0: 2020/04/14 03:59:47 [DEBUG] Unlocked "shellScriptMutexKey"
2020-04-14T03:59:47.765-0700 [DEBUG] plugin.terraform-provider-shell_v1.2.0: 2020/04/14 03:59:47 [DEBUG] State from read operation was nil. Marking resource for deletion.
```

Besides this new feature, there was some general cleanup work to the shell_script resource. As part of the emphasis on secrets management, state is no longer printed before and after an execution. You can still print the environment if you want to debug by using a normal CLI command like "printenv". `Update()` was simplified - the only thing that gets saved between runs is the output (previously, the old environment was saved but didnt do anything anyways).