### PR TITLE
fix update logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # terraform-provider-shell
 ![Go](https://github.com/scottwinkler/terraform-provider-shell/workflows/Go/badge.svg)
 ## Introduction
-This plugin is for wrapping shell scripts to make them fully fledged terraform resources. Please note that this is a backdoor into the terraform lifecycle management, so it is up to you to implement your resources properly. It is recommended that you at least have some familiarity with the internals of Terraform before attempting to use this provider. If you can't write your own provider from scratch then you probably shouldn't be using this.
+This plugin is for wrapping shell scripts to make them fully fledged terraform resources. Note that this is a backdoor into the Terraform runtime. You can do some pretty dangerous things with this and it is up to you to make sure you don't get in trouble.
 
+Since this provider is rather different than most other provider, it is recommended that you at least have some familiarity with the internals of Terraform before attempting to use this provider.
 
 ## Requirements
 
@@ -26,15 +27,19 @@ $ make build
 ```
 
 ## Installing
-To use this plugin, go to releases and download the binary for your specific OS and architecture. Then you will need to trim the name of the file to get rid of the suffix (e.g. terraform-provider-shell_v1.0.0.darwin_amd64 -> terraform-provider-shell_v1.0.0). This suffix is only used to help you identify which binary to download and will cause errors if left on. Finally, you can install this plugin by either putting it in your `~/.terraform/plugins` folder or in your terraform workspace and performing a "terraform init".
+To use this plugin, go to releases and download the binary for your specific OS and architecture. You can install the plugin by either putting it in your `~/.terraform/plugins` folder or in your terraform workspace by performing a `terraform init`.
 
-## Examples
-There is nothing to configure for the provider, you can declare it like so (or even omit it entirely):
+## Configuring the Provider
+There is nothing to configure for the provider, you can declare it like so (or omit entirely if you like):
 
 ```
 provider "shell" {}
 ```
-To use a data resource you need to implement the read command. Any output to stdout or stderr will show up in the logs, but to save the state, you must output a JSON payload to stdout. The last JSON object printed to stdout will be taken to be the state. The JSON can be a complex nested JSON, but will be flattened into a `map[string]string`. The reason for this is that your JSON payload variables can be accessed from the output map of this resource and used like a normal terraform output, so the value must be a string.
+
+## Data Sources
+The simplest example is the data source which implements only Read(). Any output to stdout or stderr will show up in the logs, but to save state, you must output a JSON payload to stdout. The last JSON object printed to stdout will be taken to be the output state. The JSON can be a complex nested JSON, but will be flattened into a `map[string]string`. The reason for this is that your JSON payload variables can be accessed from the output map of this resource and used like a normal terraform output, so the value must be a string. You can use jsondecode() to read nested JSON if you really need to.
+
+Below is an example of using the data source. The output of `whoami` is stored in a JSON object for the key `user`
 
 ```
 data "shell_script" "user" {
@@ -44,7 +49,7 @@ data "shell_script" "user" {
 		EOF
 	}
 }
-
+# "user" can be accessed like a normal Terraform map
 output "user" {
 	value = data.shell_script.user.output["user"]
 }
@@ -64,7 +69,7 @@ user = swinkler
 ```
 **Note:** the above example can be a very valuable way to get environment variables or other environment specific information into normal Terraform variables!
 
-Another data source example, this time to get the weather in San Francisco might be:
+Another data source example, this time to get the weather in San Francisco:
 
 ```
 data "shell_script" "weather" {
@@ -92,11 +97,13 @@ Outputs:
 
 weather = SanFrancisco: ⛅️ +54°F
 ```
+
+## Resources
 Resources are a bit more complicated. At a minimum, you must implement the `CREATE`, and `DELETE` lifecycle commands. `READ` and `UPDATE` are optional arguments.
 
-* If you choose not to implement the `READ` command, then `CREATE` (and `UPDATE` if you are using it) must output the state in the form of a properly formatted JSON. The local state will not be synced with the actual state, but for many applications that is not a problem.
+* If you choose not to implement the `READ` command, then `CREATE` (and `UPDATE` if you are using it) must output JSON. The local state will not be synced with the actual state, but for many applications that is not a problem.
 
-* If you choose not to implement `UPDATE`, then if a change occurs that would trigger an update, the resource will be instead be destroyed and then recreated - same as `ForceNew`. Again, for many applications this is not a problem, as `UPDATE` can be tricky to use. 
+* If you choose not to implement `UPDATE`, then if a change occurs that would trigger an update, the resource will be instead be destroyed and then recreated - same as `ForceNew`. For many applications this is not a problem.
 
 I suggest starting off with just `CREATE` and `DELETE` and then implementing `READ` and `UPDATE` only if you really need it. If you choose to implement `READ`, then you must output the state in the form of a properly formatted JSON, and you should not output the state in either the create or update scripts (otherwise it will be overridden). See the examples in the test folder for how to do each of these.
 
@@ -104,31 +111,37 @@ A complete example that uses all four lifecycle commands is shown below:
 
 	resource "shell_script" "test" {
 		lifecycle_commands {
+			# i like to have scripts be in separate files if they are non-trivial
 			create = file("${path.module}/scripts/create.sh")
 			read   = file("${path.module}/scripts/read.sh")
 			update = file("${path.module}/scripts/update.sh")
 			delete = file("${path.module}/scripts/delete.sh")
 		}
 
+		# sets current working directory.
 		working_directory = path.module
 
+		# sets environment variables
 		environment = {
-			yolo = "yolo"
-			ball = "room"
+			HELLO = "world"
+		}
+
+		# same as environment variables but won't be printed in logs or state
+		sensitive_environment = {
+			AWS_ACCESS_KEY_ID = var.aws_access_key
+		}
+
+		# triggers a force new update, like for null_resource
+		triggers = {
+			when_value_changed = var.some_value
 		}
 	}
 
-	output "commit_id" {
-		value = shell_script.test.output["commit_id"]
+	output "id" {
+		value = shell_script.test.output["id"]
 	}
 
-In the example I am setting the `working_directory` argument (which switches the current working directory), some environment variables that will be utilized by all my scripts, and configuring my lifecycle commands for `CREATE`, `READ`, `UPDATE` and `DELETE`. `CREATE`and `UPDATE` will modify the resource but not update the state, while `READ` updates the state but does not modify the resource.
-
-An example shell script resouce could have a file being written to in the `CREATE`. `READ` would simply cat that previously created file and output it to stdout. `UPDATE` could measure the changes from the old state (available through stdin) and the new state (available through environment variables) to decide how best to handle an update. Again since this is a custom resource it is up to you to decide how best to handle updates, in many cases it may make sense not to implement `UPDATE` at all and rely on just `CREATE`/`READ`/`DELETE`.
-
-`DELETE` needs to clean up any resources that were created but does not need to return anything. State data is available in the `output` variable, which is mapped from the JSON of your read command.
-
-Stdout and stderr are also available in the debug log files. You can get this by setting:
+Stdout and stderr stream to log files. You can get this by setting:
 
 ```
 export TF_LOG=debug
@@ -138,7 +151,7 @@ export TF_LOG=debug
 There is now an example for how to use the shell provider to invoke python and golang files. Please check in the `examples/python-adapter` and `examples/golang-adapter` folder for more information on this. Essentially it is an adapter around the `shell_resource` that invokes methods on an interface that you implement.
 
 ## Testing
-If you wish to build this yourself, follow the instructions:
+If you wish to run automated tests:
 
 ```sh
 $ make test

--- a/examples/complete-with-update/main.tf
+++ b/examples/complete-with-update/main.tf
@@ -1,0 +1,12 @@
+resource "shell_script" "update_test" {
+  lifecycle_commands {
+    create = file("${path.module}/scripts/create.sh")
+    read   = file("${path.module}/scripts/read.sh")
+    update = file("${path.module}/scripts/update.sh")
+    delete = file("${path.module}/scripts/delete.sh")
+  }
+
+  environment = {
+    DESCRIPTION = "somedescription"
+  }
+}

--- a/examples/complete-with-update/scripts/create.sh
+++ b/examples/complete-with-update/scripts/create.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+id=$RANDOM
+/bin/cat <<END >$id.json
+  {"id": "$id", "description": "$DESCRIPTION"}
+END
+cat $id.json

--- a/examples/complete-with-update/scripts/delete.sh
+++ b/examples/complete-with-update/scripts/delete.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+IN=$(cat)
+id=$(echo $IN | jq -r .id)
+rm ${id}.json

--- a/examples/complete-with-update/scripts/read.sh
+++ b/examples/complete-with-update/scripts/read.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+IN=$(cat)
+id=$(echo $IN | jq -r .id)
+cat ${id}.json

--- a/examples/complete-with-update/scripts/update.sh
+++ b/examples/complete-with-update/scripts/update.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+IN=$(cat)
+id=$(echo $IN | jq -r .id)
+/bin/cat <<END >$id.json
+  {"id": "$id", "description": "$DESCRIPTION"}
+END

--- a/shell/data_source_shell_script.go
+++ b/shell/data_source_shell_script.go
@@ -67,7 +67,7 @@ func dataSourceShellScriptRead(d *schema.ResourceData, meta interface{}) error {
 	output := make(map[string]string)
 
 	state := NewState(environment, sensitiveEnvironment, output)
-	newState, err := runCommand(command, state, workingDirectory)
+	newState, err := runCommand(command, workingDirectory, ReadAction, state )
 	if err != nil {
 		return err
 	}

--- a/shell/logging.go
+++ b/shell/logging.go
@@ -8,11 +8,11 @@ import (
 	"github.com/mitchellh/go-linereader"
 )
 
-func printStackTrace(stack []string) {
+func printStackTrace(actions []Action) {
 	log.Printf("-------------------------")
 	log.Printf("[DEBUG] Current stack:")
-	for _, v := range stack {
-		log.Printf("[DEBUG] -- %s", v)
+	for _, action := range actions {
+		log.Printf("[DEBUG] -- %s", action)
 	}
 	log.Printf("-------------------------")
 }

--- a/shell/logging.go
+++ b/shell/logging.go
@@ -1,0 +1,43 @@
+package shell
+
+import (
+	"io"
+	"log"
+	"strings"
+
+	"github.com/mitchellh/go-linereader"
+)
+
+func printStackTrace(stack []string) {
+	log.Printf("-------------------------")
+	log.Printf("[DEBUG] Current stack:")
+	for _, v := range stack {
+		log.Printf("[DEBUG] -- %s", v)
+	}
+	log.Printf("-------------------------")
+}
+
+func logOutput(logCh chan string, secretValues []string) {
+	for line := range logCh {
+		sanitizedLine := sanitizeString(line, secretValues)
+		log.Printf("  %s", sanitizedLine)
+	}
+}
+
+func sanitizeString(s string, secretValues []string) string {
+	for _, secret := range secretValues {
+		s = strings.ReplaceAll(s, secret, "******")
+	}
+	return s
+}
+
+func readOutput(r io.Reader, logCh chan<- string, doneCh chan<- string) {
+	defer close(doneCh)
+	lr := linereader.New(r)
+	var output strings.Builder
+	for line := range lr.Ch {
+		logCh <- line
+		output.WriteString(line)
+	}
+	doneCh <- output.String()
+}

--- a/shell/resource_shell_script.go
+++ b/shell/resource_shell_script.go
@@ -83,22 +83,22 @@ func resourceShellScript() *schema.Resource {
 
 //helpers to unwravel the recursive bits by adding a base condition
 func resourceShellScriptCreate(d *schema.ResourceData, meta interface{}) error {
-	return create(d, meta, []string{"create"})
+	return create(d, meta, []Action{ActionCreate})
 }
 
 func resourceShellScriptRead(d *schema.ResourceData, meta interface{}) error {
-	return read(d, meta, []string{"read"})
+	return read(d, meta, []Action{ActionRead})
 }
 
 func resourceShellScriptUpdate(d *schema.ResourceData, meta interface{}) error {
-	return update(d, meta, []string{"update"})
+	return update(d, meta, []Action{ActionUpdate})
 }
 
 func resourceShellScriptDelete(d *schema.ResourceData, meta interface{}) error {
-	return delete(d, meta, []string{"delete"})
+	return delete(d, meta, []Action{ActionDelete})
 }
 
-func create(d *schema.ResourceData, meta interface{}, stack []string) error {
+func create(d *schema.ResourceData, meta interface{}, stack []Action) error {
 	log.Printf("[DEBUG] Creating shell script resource...")
 	printStackTrace(stack)
 	l := d.Get("lifecycle_commands").([]interface{})
@@ -108,21 +108,26 @@ func create(d *schema.ResourceData, meta interface{}, stack []string) error {
 	sensitiveEnvironment := packEnvironmentVariables(d.Get("sensitive_environment"))
 	workingDirectory := d.Get("working_directory").(string)
 	d.MarkNewResource()
-	output := make(map[string]string)
-	state := NewState(environment, sensitiveEnvironment, output)
-	newState, err := runCommand(command, workingDirectory, CreateAction, state)
+	commandConfig := &CommandConfig{
+		Command:              command,
+		Environment:          environment,
+		SensitiveEnvironment: sensitiveEnvironment,
+		WorkingDirectory:     workingDirectory,
+		Action:               ActionCreate,
+	}
+	output, err := runCommand(commandConfig)
 	if err != nil {
 		return err
 	}
 
-	//if create doesn't return a new state then must call the read operation
-	if newState == nil {
-		stack = append(stack, "read")
+	//if create doesn't return output then assume we should call the read operation
+	if output == nil {
+		stack = append(stack, ActionRead)
 		if err := read(d, meta, stack); err != nil {
 			return err
 		}
 	} else {
-		d.Set("output", newState.Output)
+		d.Set("output", output)
 	}
 
 	//create random uuid for the id
@@ -131,7 +136,7 @@ func create(d *schema.ResourceData, meta interface{}, stack []string) error {
 	return nil
 }
 
-func read(d *schema.ResourceData, meta interface{}, stack []string) error {
+func read(d *schema.ResourceData, meta interface{}, stack []Action) error {
 	log.Printf("[DEBUG] Reading shell script resource...")
 	printStackTrace(stack)
 	l := d.Get("lifecycle_commands").([]interface{})
@@ -146,36 +151,43 @@ func read(d *schema.ResourceData, meta interface{}, stack []string) error {
 	environment := packEnvironmentVariables(d.Get("environment"))
 	sensitiveEnvironment := packEnvironmentVariables(d.Get("sensitive_environment"))
 	workingDirectory := d.Get("working_directory").(string)
-	output := expandOutput(d.Get("output"))
+	previousOutput := expandOutput(d.Get("output"))
 
-	state := NewState(environment, sensitiveEnvironment, output)
-	newState, err := runCommand(command, workingDirectory, ReadAction, state)
+	commandConfig := &CommandConfig{
+		Command:              command,
+		Environment:          environment,
+		SensitiveEnvironment: sensitiveEnvironment,
+		WorkingDirectory:     workingDirectory,
+		Action:               ActionRead,
+		PreviousOutput:       previousOutput,
+	}
+	output, err := runCommand(commandConfig)
 	if err != nil {
 		return err
 	}
 
-	if newState == nil {
+	if output == nil {
 		log.Printf("[DEBUG] State from read operation was nil. Marking resource for deletion.")
 		d.SetId("")
 		return nil
 	}
 	log.Printf("[DEBUG] previous output:|%v|", output)
-	log.Printf("[DEBUG] new output:|%v|", newState.Output)
-	isStateEqual := reflect.DeepEqual(output, newState.Output)
+	log.Printf("[DEBUG] new output:|%v|", previousOutput)
+	isStateEqual := reflect.DeepEqual(output, previousOutput)
 	isNewResource := d.IsNewResource()
-	isUpdatedResource := stack[0] == "update"
+	isUpdatedResource := stack[0] == ActionUpdate
 	if !isStateEqual && !isNewResource && !isUpdatedResource {
 		log.Printf("[DEBUG] Previous state not equal to new state. Marking resource as dirty to trigger update.")
 		d.Set("dirty", true)
 		return nil
 	}
 
-	d.Set("output", newState.Output)
+	d.Set("output", output)
 
 	return nil
 }
 
-func update(d *schema.ResourceData, meta interface{}, stack []string) error {
+func update(d *schema.ResourceData, meta interface{}, stack []Action) error {
 	log.Printf("[DEBUG] Updating shell script resource...")
 	d.Set("dirty", false)
 	printStackTrace(stack)
@@ -185,36 +197,43 @@ func update(d *schema.ResourceData, meta interface{}, stack []string) error {
 
 	//if update is not set, then treat it simply as a tainted resource - delete then recreate
 	if len(command) == 0 {
-		stack = append(stack, "delete")
+		stack = append(stack, ActionDelete)
 		delete(d, meta, stack)
-		stack = append(stack, "create")
+		stack = append(stack, ActionCreate)
 		return create(d, meta, stack)
 	}
 
 	environment := packEnvironmentVariables(d.Get("environment"))
 	sensitiveEnvironment := packEnvironmentVariables(d.Get("sensitive_environment"))
 	workingDirectory := d.Get("working_directory").(string)
-	output := expandOutput(d.Get("output"))
+	previousOutput := expandOutput(d.Get("output"))
 
-	state := NewState(environment, sensitiveEnvironment, output)
-	newState, err := runCommand(command, workingDirectory, UpdateAction, state)
+	commandConfig := &CommandConfig{
+		Command:              command,
+		Environment:          environment,
+		SensitiveEnvironment: sensitiveEnvironment,
+		WorkingDirectory:     workingDirectory,
+		Action:               ActionDelete,
+		PreviousOutput:       previousOutput,
+	}
+	output, err := runCommand(commandConfig)
 	if err != nil {
 		return err
 	}
 
-	//if update doesn't return a new state then must call the read operation
-	if newState == nil {
-		stack = append(stack, "read")
+	//if update doesn't return output then must call the read operation
+	if output == nil {
+		stack = append(stack, ActionRead)
 		if err := read(d, meta, stack); err != nil {
 			return err
 		}
 	} else {
-		d.Set("output", newState.Output)
+		d.Set("output", output)
 	}
 	return nil
 }
 
-func delete(d *schema.ResourceData, meta interface{}, stack []string) error {
+func delete(d *schema.ResourceData, meta interface{}, stack []Action) error {
 	log.Printf("[DEBUG] Deleting shell script resource...")
 	printStackTrace(stack)
 	l := d.Get("lifecycle_commands").([]interface{})
@@ -223,10 +242,17 @@ func delete(d *schema.ResourceData, meta interface{}, stack []string) error {
 	environment := packEnvironmentVariables(d.Get("environment"))
 	sensitiveEnvironment := packEnvironmentVariables(d.Get("sensitive_environment"))
 	workingDirectory := d.Get("working_directory").(string)
-	output := expandOutput(d.Get("output"))
+	previousOutput := expandOutput(d.Get("output"))
 
-	state := NewState(environment, sensitiveEnvironment, output)
-	_, err := runCommand(command, workingDirectory, DeleteAction, state)
+	commandConfig := &CommandConfig{
+		Command:              command,
+		Environment:          environment,
+		SensitiveEnvironment: sensitiveEnvironment,
+		WorkingDirectory:     workingDirectory,
+		Action:               ActionDelete,
+		PreviousOutput:       previousOutput,
+	}
+	_, err := runCommand(commandConfig)
 	if err != nil {
 		return err
 	}
@@ -234,13 +260,18 @@ func delete(d *schema.ResourceData, meta interface{}, stack []string) error {
 	return nil
 }
 
+//Action is an enum for CRUD operations
 type Action string
 
 const (
-	CreateAction Action = "create"
-	ReadAction   Action = "read"
-	UpdateAction Action = "update"
-	DeleteAction Action = "delete"
+	//ActionCreate ...
+	ActionCreate Action = "create"
+	//ActionRead ...
+	ActionRead Action = "read"
+	//ActionUpdate ...
+	ActionUpdate Action = "update"
+	//ActionDelete ...
+	ActionDelete Action = "delete"
 )
 
 func expandOutput(o interface{}) map[string]string {


### PR DESCRIPTION
Update logic was greatly simplified. Documentation was improved, and a better update example was added.

Update() and Delete() are no longer marked ForceNew because this can cause weird problems if you are stuck in an error condition.

Many other changes are purely cosmetic or organizational in nature. For example, names of State was changed to CommandConfig. which was done to be more consistent and easier to understand. A new enum was added for Actions instead of using strings. Environment variables are no longer considered "State", only Output is considered state from the point of view of a resource.