### PR TITLE
Zd/provider config

### DIFF
--- a/shell/config.go
+++ b/shell/config.go
@@ -2,14 +2,19 @@ package shell
 
 //Config is the config for the client.
 type Config struct {
+	Environment map[string]interface{}
 }
 
 //Client is the client itself. Since we already have access to the shell no real provisioning needs to be done
 type Client struct {
+	config *Config
 }
 
 // Client configures and returns a fully initialized ShellClient
 func (c *Config) Client() (interface{}, error) {
-	var client Client
-	return &client, nil
+	client := &Client{
+		config: c,
+	}
+
+	return client, nil
 }

--- a/shell/config.go
+++ b/shell/config.go
@@ -11,7 +11,7 @@ type Client struct {
 }
 
 // Client configures and returns a fully initialized ShellClient
-func (c *Config) Client() (interface{}, error) {
+func (c *Config) Client() (*Client, error) {
 	client := &Client{
 		config: c,
 	}

--- a/shell/data_source_shell_script.go
+++ b/shell/data_source_shell_script.go
@@ -61,7 +61,9 @@ func dataSourceShellScriptRead(d *schema.ResourceData, meta interface{}) error {
 	value := c["read"]
 
 	command := value.(string)
-	environment := flattenEnvironmentVariables(d.Get("environment"))
+	client := meta.(*Client)
+	envVariables := getEnvironmentVariables(client, d)
+	environment := flattenEnvironmentVariables(envVariables)
 	sensitiveEnvironment := flattenEnvironmentVariables(d.Get("sensitive_environment"))
 	workingDirectory := d.Get("working_directory").(string)
 

--- a/shell/data_source_shell_script_test.go
+++ b/shell/data_source_shell_script_test.go
@@ -26,6 +26,37 @@ func TestAccShellDataShellScript_basic(t *testing.T) {
 	})
 }
 
+func TestAccShellDataShellScript_withEnv(t *testing.T) {
+	resourceName := "data.shell_script.test"
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceShellScriptWithEnv,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "environment.TOKEN", "valueX"),
+					resource.TestCheckResourceAttr(resourceName, "output.value", "valueX"),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+				),
+			},
+			{
+				Config: testDataSourceShellScriptWithProviderEnv,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "output.value", "Env1_Val01"),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+				),
+			},
+			{
+				Config: testDataSourceShellScriptEnvOverridesProviderEnv,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "output.value", "override_val"),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataShellScriptConfig(outValue string) string {
 	return fmt.Sprintf(`
 	data "shell_script" "test" {
@@ -37,3 +68,39 @@ EOF
 	}
 `, outValue)
 }
+
+var testDataSourceShellScriptWithEnv = `
+data "shell_script" "test" {
+	lifecycle_commands {
+	read = <<EOF
+		echo "{\"value\": \"$TOKEN\"}"
+EOF
+	}
+	environment = {
+		"TOKEN" = "valueX"
+	}
+}
+`
+
+var testDataSourceShellScriptWithProviderEnv = `
+data "shell_script" "test" {
+	lifecycle_commands {
+	read = <<EOF
+		echo "{\"value\": \"$TEST_ENV1\"}"
+EOF
+	}
+}
+`
+
+var testDataSourceShellScriptEnvOverridesProviderEnv = `
+data "shell_script" "test" {
+	lifecycle_commands {
+	read = <<EOF
+		echo "{\"value\": \"$TEST_ENV1\"}"
+EOF
+	}
+	environment = {
+		"TEST_ENV1" = "override_val"
+	}
+}
+`

--- a/shell/provider.go
+++ b/shell/provider.go
@@ -11,7 +11,13 @@ func Provider() terraform.ResourceProvider {
 
 	// The actual provider
 	return &schema.Provider{
-		Schema: map[string]*schema.Schema{},
+		Schema: map[string]*schema.Schema{
+			"environment": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     schema.TypeString,
+			},
+		},
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"shell_script": dataSourceShellScript(),
@@ -25,7 +31,9 @@ func Provider() terraform.ResourceProvider {
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
-	config := Config{}
+	config := Config{
+		Environment: d.Get("environment").(map[string]interface{}),
+	}
 	return config.Client()
 }
 

--- a/shell/provider_test.go
+++ b/shell/provider_test.go
@@ -13,6 +13,8 @@ var testAccProvider *schema.Provider
 
 func init() {
 	testAccProvider = Provider().(*schema.Provider)
+	testAccProvider.ConfigureFunc = testProviderConfigure
+
 	testAccProviders = map[string]terraform.ResourceProvider{
 		"shell": testAccProvider,
 	}
@@ -54,4 +56,14 @@ func TestProvider_HasChildDataSources(t *testing.T) {
 		require.Contains(t, dataSources, resource, "An expected data source was not registered")
 		require.NotNil(t, dataSources[resource], "A data source cannot have a nil schema")
 	}
+}
+
+func testProviderConfigure(d *schema.ResourceData) (interface{}, error) {
+	config := Config{}
+	config.Environment = map[string]interface{}{
+		"TEST_ENV1": "Env1_Val01",
+		"TEST_ENV2": "Env2_Val02",
+	}
+
+	return config.Client()
 }

--- a/shell/provider_test.go
+++ b/shell/provider_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/stretchr/testify/require"
 )
 
 var testAccProviders map[string]terraform.ResourceProvider
@@ -25,4 +26,32 @@ func TestProvider(t *testing.T) {
 
 func TestProvider_impl(t *testing.T) {
 	var _ terraform.ResourceProvider = Provider()
+}
+
+func TestProvider_HasChildResources(t *testing.T) {
+	expectedResources := []string{
+		"shell_script",
+	}
+
+	resources := testAccProvider.ResourcesMap
+	require.Equal(t, len(expectedResources), len(resources), "There are an unexpected number of registered resources")
+
+	for _, resource := range expectedResources {
+		require.Contains(t, resources, resource, "An expected resource was not registered")
+		require.NotNil(t, resources[resource], "A resource cannot have a nil schema")
+	}
+}
+
+func TestProvider_HasChildDataSources(t *testing.T) {
+	expectedDataSources := []string{
+		"shell_script",
+	}
+
+	dataSources := testAccProvider.DataSourcesMap
+	require.Equal(t, len(expectedDataSources), len(dataSources), "There are an unexpected number of registered data sources")
+
+	for _, resource := range expectedDataSources {
+		require.Contains(t, dataSources, resource, "An expected data source was not registered")
+		require.NotNil(t, dataSources[resource], "A data source cannot have a nil schema")
+	}
 }

--- a/shell/resource_shell_script.go
+++ b/shell/resource_shell_script.go
@@ -101,11 +101,15 @@ func resourceShellScriptDelete(d *schema.ResourceData, meta interface{}) error {
 func create(d *schema.ResourceData, meta interface{}, stack []Action) error {
 	log.Printf("[DEBUG] Creating shell script resource...")
 	printStackTrace(stack)
+
+	client := meta.(*Client)
 	l := d.Get("lifecycle_commands").([]interface{})
 	c := l[0].(map[string]interface{})
 	command := c["create"].(string)
-	environment := flattenEnvironmentVariables(d.Get("environment"))
+	envVariables := getEnvironmentVariables(client, d)
+	environment := flattenEnvironmentVariables(envVariables)
 	sensitiveEnvironment := flattenEnvironmentVariables(d.Get("sensitive_environment"))
+
 	workingDirectory := d.Get("working_directory").(string)
 	d.MarkNewResource()
 	commandConfig := &CommandConfig{
@@ -148,7 +152,9 @@ func read(d *schema.ResourceData, meta interface{}, stack []Action) error {
 		return nil
 	}
 
-	environment := flattenEnvironmentVariables(d.Get("environment"))
+	client := meta.(*Client)
+	envVariables := getEnvironmentVariables(client, d)
+	environment := flattenEnvironmentVariables(envVariables)
 	sensitiveEnvironment := flattenEnvironmentVariables(d.Get("sensitive_environment"))
 	workingDirectory := d.Get("working_directory").(string)
 	previousOutput := expandOutput(d.Get("output"))
@@ -203,7 +209,9 @@ func update(d *schema.ResourceData, meta interface{}, stack []Action) error {
 		return create(d, meta, stack)
 	}
 
-	environment := flattenEnvironmentVariables(d.Get("environment"))
+	client := meta.(*Client)
+	envVariables := getEnvironmentVariables(client, d)
+	environment := flattenEnvironmentVariables(envVariables)
 	sensitiveEnvironment := flattenEnvironmentVariables(d.Get("sensitive_environment"))
 	workingDirectory := d.Get("working_directory").(string)
 	previousOutput := expandOutput(d.Get("output"))
@@ -239,7 +247,10 @@ func delete(d *schema.ResourceData, meta interface{}, stack []Action) error {
 	l := d.Get("lifecycle_commands").([]interface{})
 	c := l[0].(map[string]interface{})
 	command := c["delete"].(string)
-	environment := flattenEnvironmentVariables(d.Get("environment"))
+
+	client := meta.(*Client)
+	envVariables := getEnvironmentVariables(client, d)
+	environment := flattenEnvironmentVariables(envVariables)
 	sensitiveEnvironment := flattenEnvironmentVariables(d.Get("sensitive_environment"))
 	workingDirectory := d.Get("working_directory").(string)
 	previousOutput := expandOutput(d.Get("output"))

--- a/shell/resource_shell_script.go
+++ b/shell/resource_shell_script.go
@@ -102,10 +102,10 @@ func create(d *schema.ResourceData, meta interface{}, stack []Action) error {
 	log.Printf("[DEBUG] Creating shell script resource...")
 	printStackTrace(stack)
 
-	client := meta.(*Client)
 	l := d.Get("lifecycle_commands").([]interface{})
 	c := l[0].(map[string]interface{})
 	command := c["create"].(string)
+	client := meta.(*Client)
 	envVariables := getEnvironmentVariables(client, d)
 	environment := flattenEnvironmentVariables(envVariables)
 	sensitiveEnvironment := flattenEnvironmentVariables(d.Get("sensitive_environment"))

--- a/shell/utility.go
+++ b/shell/utility.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/tidwall/gjson"
 )
 
@@ -174,4 +175,17 @@ func readFile(r io.Reader) string {
 		buffer.Write(tmpdata)
 	}
 	return buffer.String()
+}
+
+func getEnvironmentVariables(client *Client, d *schema.ResourceData) map[string]interface{} {
+	variables := make(map[string]interface{})
+	resEnv := d.Get("environment").(map[string]interface{})
+	for k, v := range resEnv {
+		variables[k] = v
+	}
+	for k, v := range client.config.Environment {
+		variables[k] = v
+	}
+
+	return variables
 }

--- a/shell/utility.go
+++ b/shell/utility.go
@@ -180,10 +180,10 @@ func readFile(r io.Reader) string {
 func getEnvironmentVariables(client *Client, d *schema.ResourceData) map[string]interface{} {
 	variables := make(map[string]interface{})
 	resEnv := d.Get("environment").(map[string]interface{})
-	for k, v := range resEnv {
+	for k, v := range client.config.Environment {
 		variables[k] = v
 	}
-	for k, v := range client.config.Environment {
+	for k, v := range resEnv {
 		variables[k] = v
 	}
 


### PR DESCRIPTION
Implementation for PR for #49 .

Let's you set variables on the shell provider so they are always passed in on each script execution.   Allows resources that are being deleted to get up-to-date env values if they need it.

Edit:
The environment variables on the resource take priority over the provider environment variables.  

Example:

```hcl
resource "random_string" "random" {
  length = 5
}

provider "shell" {
    environment = {
        "TOKEN" = random_string.random.result
    }
}

resource "shell_script" "test" {
    lifecycle_commands {
    create = <<-EOF
        echo "$TOKEN" > create.txt
        echo "{\"VAR\": \"$TOKEN\"}"
    EOF

    delete = <<-EOF
        echo "$TOKEN" > delete.txt
        echo "{\"VAR\": \"$TOKEN\"}"
    EOF
  }
} 
```