### PR TITLE
fix secrets bug

### DIFF
--- a/examples/github-repo/main.tf
+++ b/examples/github-repo/main.tf
@@ -1,9 +1,15 @@
 variable "oauth_token" {
-    type = string
+  type = string
+}
+
+provider "shell" {
+  sensitive_environment = {
+    OAUTH_TOKEN = var.oauth_token
+  }
 }
 
 resource "shell_script" "github_repository" {
-   lifecycle_commands {
+  lifecycle_commands {
     create = file("${path.module}/scripts/create.sh")
     read   = file("${path.module}/scripts/read.sh")
     update = file("${path.module}/scripts/update.sh")
@@ -11,10 +17,7 @@ resource "shell_script" "github_repository" {
   }
 
   environment = {
-    NAME = "HELLO-WORLD"
+    NAME        = "HELLO-WORLD"
     DESCRIPTION = "description"
-  }
-  sensitive_environment = {
-    OAUTH_TOKEN = var.oauth_token
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/packer-community/winrmcp v0.0.0-20180921211025-c76d91c1e7db // indirect
 	github.com/rs/xid v1.2.1
 	github.com/ryanuber/columnize v2.1.0+incompatible // indirect
+	github.com/stretchr/testify v1.4.0
 	github.com/terraform-providers/terraform-provider-aws v1.60.0 // indirect
 	github.com/terraform-providers/terraform-provider-openstack v1.26.0 // indirect
 	github.com/tidwall/gjson v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1155,6 +1155,7 @@ github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d h1:Z4EH+5EffvBEhh37F0C0DnpklTMh00JOkjW5zK3ofBI=
 github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d/go.mod h1:BSTlc8jOjh0niykqEGVXOLXdi9o0r0kR8tCYiMvjFgw=

--- a/shell/config.go
+++ b/shell/config.go
@@ -3,6 +3,7 @@ package shell
 //Config is the config for the client.
 type Config struct {
 	Environment map[string]interface{}
+	SensitiveEnvironment map[string]interface{}
 }
 
 //Client is the client itself. Since we already have access to the shell no real provisioning needs to be done

--- a/shell/config.go
+++ b/shell/config.go
@@ -2,7 +2,7 @@ package shell
 
 //Config is the config for the client.
 type Config struct {
-	Environment map[string]interface{}
+	Environment          map[string]interface{}
 	SensitiveEnvironment map[string]interface{}
 }
 

--- a/shell/data_source_shell_script.go
+++ b/shell/data_source_shell_script.go
@@ -63,8 +63,9 @@ func dataSourceShellScriptRead(d *schema.ResourceData, meta interface{}) error {
 	command := value.(string)
 	client := meta.(*Client)
 	envVariables := getEnvironmentVariables(client, d)
-	environment := flattenEnvironmentVariables(envVariables)
-	sensitiveEnvironment := flattenEnvironmentVariables(d.Get("sensitive_environment"))
+	environment := formatEnvironmentVariables(envVariables)
+	sensitiveEnvVariables := getSensitiveEnvironmentVariables(client, d)
+	sensitiveEnvironment := formatEnvironmentVariables(sensitiveEnvVariables)
 	workingDirectory := d.Get("working_directory").(string)
 
 	//we don't care about previous output for data sources

--- a/shell/logging.go
+++ b/shell/logging.go
@@ -1,6 +1,7 @@
 package shell
 
 import (
+	"bytes"
 	"io"
 	"log"
 	"strings"
@@ -25,10 +26,12 @@ func logOutput(logCh chan string, secretValues []string) {
 }
 
 func sanitizeString(s string, secretValues []string) string {
+	newString := s
 	for _, secret := range secretValues {
-		s = strings.ReplaceAll(s, secret, "******")
+		replacement := strings.Repeat("*", len(s))
+		newString = strings.ReplaceAll(newString, secret, replacement)
 	}
-	return s
+	return newString
 }
 
 func readOutput(r io.Reader, logCh chan<- string, doneCh chan<- string) {
@@ -40,4 +43,18 @@ func readOutput(r io.Reader, logCh chan<- string, doneCh chan<- string) {
 		output.WriteString(line)
 	}
 	doneCh <- output.String()
+}
+
+func readFile(r io.Reader) string {
+	const maxBufSize = 8 * 1024
+	buffer := new(bytes.Buffer)
+	for {
+		tmpdata := make([]byte, maxBufSize)
+		bytecount, _ := r.Read(tmpdata)
+		if bytecount == 0 {
+			break
+		}
+		buffer.Write(tmpdata)
+	}
+	return buffer.String()
 }

--- a/shell/provider.go
+++ b/shell/provider.go
@@ -17,6 +17,11 @@ func Provider() terraform.ResourceProvider {
 				Optional: true,
 				Elem:     schema.TypeString,
 			},
+			"sensitive_environment": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     schema.TypeString,
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -32,7 +37,8 @@ func Provider() terraform.ResourceProvider {
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
-		Environment: d.Get("environment").(map[string]interface{}),
+		Environment:          d.Get("environment").(map[string]interface{}),
+		SensitiveEnvironment: d.Get("sensitive_environment").(map[string]interface{}),
 	}
 	return config.Client()
 }


### PR DESCRIPTION
Closes ticket #47. Sanitized stdout was being used to read output json, which is a problem if there is sensitive data in the json itself. Fixed this. Still have problem sanitizing multi-line sensitive data, but that is a bit more complicated and will probably need its own ticket to address. 

Besides closing this ticket, also the documentation was updated and sensitive_environment was added to the provider config.