### PR TITLE
add interpreter

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -778,6 +778,7 @@ github.com/hashicorp/terraform-plugin-sdk v1.7.0 h1:B//oq0ZORG+EkVrIJy0uPGSonvmX
 github.com/hashicorp/terraform-plugin-sdk v1.7.0/go.mod h1:OjgQmey5VxnPej/buEhe+YqKm0KNvV3QqU4hkqHqPCY=
 github.com/hashicorp/terraform-plugin-sdk v1.8.0 h1:HE1p52nzcgz88hIJmapUnkmM9noEjV3QhTOLaua5XUA=
 github.com/hashicorp/terraform-plugin-sdk v1.9.1 h1:AgHnd6yPCg7o57XWrv4L7tIMdF0KQpcZro1pDHF1Xbw=
+github.com/hashicorp/terraform-plugin-sdk v1.12.0 h1:HPp65ShSsKUMPf6jD50UQn/xAjyrGVO4FxI63bvu+pc=
 github.com/hashicorp/terraform-plugin-test v1.2.0 h1:AWFdqyfnOj04sxTdaAF57QqvW7XXrT8PseUHkbKsE8I=
 github.com/hashicorp/terraform-plugin-test v1.2.0/go.mod h1:QIJHYz8j+xJtdtLrFTlzQVC0ocr3rf/OjIpgZLK56Hs=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596 h1:hjyO2JsNZUKT1ym+FAdlBEkGPevazYsmVgIMw7dVELg=

--- a/shell/config.go
+++ b/shell/config.go
@@ -4,6 +4,7 @@ package shell
 type Config struct {
 	Environment          map[string]interface{}
 	SensitiveEnvironment map[string]interface{}
+	Interpreter          []interface{}
 }
 
 //Client is the client itself. Since we already have access to the shell no real provisioning needs to be done

--- a/shell/data_source_shell_script.go
+++ b/shell/data_source_shell_script.go
@@ -39,6 +39,14 @@ func dataSourceShellScript() *schema.Resource {
 				Elem:      schema.TypeString,
 				Sensitive: true,
 			},
+			"interpreter": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			"working_directory": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -66,6 +74,7 @@ func dataSourceShellScriptRead(d *schema.ResourceData, meta interface{}) error {
 	environment := formatEnvironmentVariables(envVariables)
 	sensitiveEnvVariables := getSensitiveEnvironmentVariables(client, d)
 	sensitiveEnvironment := formatEnvironmentVariables(sensitiveEnvVariables)
+	interpreter := getInterpreter(client, d)
 	workingDirectory := d.Get("working_directory").(string)
 
 	//we don't care about previous output for data sources
@@ -76,6 +85,7 @@ func dataSourceShellScriptRead(d *schema.ResourceData, meta interface{}) error {
 		Environment:          environment,
 		SensitiveEnvironment: sensitiveEnvironment,
 		WorkingDirectory:     workingDirectory,
+		Interpreter:          interpreter,
 		Action:               ActionRead,
 		PreviousOutput:       previousOutput,
 	}

--- a/shell/provider.go
+++ b/shell/provider.go
@@ -18,9 +18,17 @@ func Provider() terraform.ResourceProvider {
 				Elem:     schema.TypeString,
 			},
 			"sensitive_environment": {
-				Type:     schema.TypeMap,
+				Type:      schema.TypeMap,
+				Optional:  true,
+				Sensitive: true,
+				Elem:      schema.TypeString,
+			},
+			"interpreter": {
+				Type:     schema.TypeList,
 				Optional: true,
-				Elem:     schema.TypeString,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
 			},
 		},
 
@@ -36,9 +44,22 @@ func Provider() terraform.ResourceProvider {
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+	var environment map[string]interface{}
+	if v, ok := d.GetOk("environment"); ok {
+		environment = v.(map[string]interface{})
+	}
+	var sensitiveEnvironment map[string]interface{}
+	if v, ok := d.GetOk("sensitive_environment"); ok {
+		sensitiveEnvironment = v.(map[string]interface{})
+	}
+	var interpreter []interface{}
+	if v, ok := d.GetOk("interpreter"); ok {
+		interpreter = v.([]interface{})
+	}
 	config := Config{
-		Environment:          d.Get("environment").(map[string]interface{}),
-		SensitiveEnvironment: d.Get("sensitive_environment").(map[string]interface{}),
+		Environment:          environment,
+		SensitiveEnvironment: sensitiveEnvironment,
+		Interpreter:          interpreter,
 	}
 	return config.Client()
 }


### PR DESCRIPTION
This closes PR #37 .

A new interpreter attribute is added to the provider and data source + managed resource. This allows users to overwrite the default interpreter. The order of precedence is: default interpreter <  provider supplied interpreter < resource supplied interpreter.

Here is an example of configuring the provider:

```
provider "shell" {
	interpreter = ["/bin/bash", "-c"]
}
```

and here is an example of configuring a resource:
```
resource "shell_script" "example" {
	lifecycle_commands {
		create = file("${path.module}/scripts/create.sh")
		read   = file("${path.module}/scripts/read.sh")
		update = file("${path.module}/scripts/update.sh")
		delete = file("${path.module}/scripts/delete.sh")
	}

	interpreter = ["/bin/bash", "-c"]
}
```