### PR TITLE
add enable_parallelism

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ provider "shell" {
 }
 ```
 
-Additionally, you can configure the provider with an optional `interpreter` flag which will set the interpreter for all resources. If you do not specify this, then the default shell for your machine will be used.
+Additionally, you can configure the provider with an optional `interpreter` and `enable_parallelism` flags. If you do not specify an interpreter, then the default shell for your machine will be used. Meanwhile, `enable_parallelism` defaults to false but can be turned on if you want to speed things up.
 
 ```
 provider "shell" {
 	interpreter = ["/bin/bash", "-c"]
+	enable_parallelism = true
 }
 ```
-
 ## Data Sources
 The simplest example is the data source which implements only Read(). Any output to stdout or stderr will show up in the logs, but to save state, you must output a JSON payload to stdout. The last JSON object printed to stdout will be taken to be the output state. The JSON can be a complex nested JSON, but will be flattened into a `map[string]string`. The reason for this is that your JSON payload variables can be accessed from the output map of this resource and used like a normal terraform output, so the value must be a string. You can use the built-in jsondecode() function to read nested JSON values if you really need to.
 
@@ -139,6 +139,7 @@ provider "shell" {
 		OAUTH_TOKEN = var.oauth_token
 	}
 	interpreter = ["/bin/sh", "-c"]
+	enable_parallelism = false
 }
 
 resource "shell_script" "github_repository" {

--- a/shell/config.go
+++ b/shell/config.go
@@ -5,6 +5,7 @@ type Config struct {
 	Environment          map[string]interface{}
 	SensitiveEnvironment map[string]interface{}
 	Interpreter          []interface{}
+	EnableParallelism    bool
 }
 
 //Client is the client itself. Since we already have access to the shell no real provisioning needs to be done

--- a/shell/data_source_shell_script.go
+++ b/shell/data_source_shell_script.go
@@ -76,6 +76,7 @@ func dataSourceShellScriptRead(d *schema.ResourceData, meta interface{}) error {
 	sensitiveEnvironment := formatEnvironmentVariables(sensitiveEnvVariables)
 	interpreter := getInterpreter(client, d)
 	workingDirectory := d.Get("working_directory").(string)
+	enableParallelism := client.config.EnableParallelism
 
 	//we don't care about previous output for data sources
 	previousOutput := make(map[string]string)
@@ -88,6 +89,7 @@ func dataSourceShellScriptRead(d *schema.ResourceData, meta interface{}) error {
 		Interpreter:          interpreter,
 		Action:               ActionRead,
 		PreviousOutput:       previousOutput,
+		EnableParallelism:    enableParallelism,
 	}
 	output, err := runCommand(commandConfig)
 	if err != nil {

--- a/shell/provider.go
+++ b/shell/provider.go
@@ -30,6 +30,11 @@ func Provider() terraform.ResourceProvider {
 					Type: schema.TypeString,
 				},
 			},
+			"enable_parallelism": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -56,10 +61,13 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	if v, ok := d.GetOk("interpreter"); ok {
 		interpreter = v.([]interface{})
 	}
+	enableParallelism := d.Get("enable_parallelism").(bool)
+
 	config := Config{
 		Environment:          environment,
 		SensitiveEnvironment: sensitiveEnvironment,
 		Interpreter:          interpreter,
+		EnableParallelism:    enableParallelism,
 	}
 	return config.Client()
 }

--- a/shell/resource_shell_script.go
+++ b/shell/resource_shell_script.go
@@ -122,6 +122,7 @@ func create(d *schema.ResourceData, meta interface{}, stack []Action) error {
 	sensitiveEnvironment := formatEnvironmentVariables(sensitiveEnvVariables)
 	interpreter := getInterpreter(client, d)
 	workingDirectory := d.Get("working_directory").(string)
+	enableParallelism := client.config.EnableParallelism
 	d.MarkNewResource()
 
 	commandConfig := &CommandConfig{
@@ -131,6 +132,7 @@ func create(d *schema.ResourceData, meta interface{}, stack []Action) error {
 		WorkingDirectory:     workingDirectory,
 		Interpreter:          interpreter,
 		Action:               ActionCreate,
+		EnableParallelism:    enableParallelism,
 	}
 	output, err := runCommand(commandConfig)
 	if err != nil {
@@ -147,9 +149,13 @@ func create(d *schema.ResourceData, meta interface{}, stack []Action) error {
 		d.Set("output", output)
 	}
 
-	//create random uuid for the id
-	id := xid.New().String()
-	d.SetId(id)
+	//create random uuid for the id only if output has been set
+	savedOutput := d.Get("output")
+	if savedOutput != nil {
+		id := xid.New().String()
+		d.SetId(id)
+	}
+
 	return nil
 }
 
@@ -173,6 +179,7 @@ func read(d *schema.ResourceData, meta interface{}, stack []Action) error {
 	interpreter := getInterpreter(client, d)
 	workingDirectory := d.Get("working_directory").(string)
 	previousOutput := expandOutput(d.Get("output"))
+	enableParallelism := client.config.EnableParallelism
 
 	commandConfig := &CommandConfig{
 		Command:              command,
@@ -182,6 +189,7 @@ func read(d *schema.ResourceData, meta interface{}, stack []Action) error {
 		Interpreter:          interpreter,
 		Action:               ActionRead,
 		PreviousOutput:       previousOutput,
+		EnableParallelism:    enableParallelism,
 	}
 	output, err := runCommand(commandConfig)
 	if err != nil {
@@ -233,6 +241,7 @@ func update(d *schema.ResourceData, meta interface{}, stack []Action) error {
 	interpreter := getInterpreter(client, d)
 	workingDirectory := d.Get("working_directory").(string)
 	previousOutput := expandOutput(d.Get("output"))
+	enableParallelism := client.config.EnableParallelism
 
 	commandConfig := &CommandConfig{
 		Command:              command,
@@ -242,6 +251,7 @@ func update(d *schema.ResourceData, meta interface{}, stack []Action) error {
 		Interpreter:          interpreter,
 		Action:               ActionDelete,
 		PreviousOutput:       previousOutput,
+		EnableParallelism:    enableParallelism,
 	}
 	output, err := runCommand(commandConfig)
 	if err != nil {
@@ -275,6 +285,7 @@ func delete(d *schema.ResourceData, meta interface{}, stack []Action) error {
 	interpreter := getInterpreter(client, d)
 	workingDirectory := d.Get("working_directory").(string)
 	previousOutput := expandOutput(d.Get("output"))
+	enableParallelism := client.config.EnableParallelism
 
 	commandConfig := &CommandConfig{
 		Command:              command,
@@ -284,6 +295,7 @@ func delete(d *schema.ResourceData, meta interface{}, stack []Action) error {
 		Interpreter:          interpreter,
 		Action:               ActionDelete,
 		PreviousOutput:       previousOutput,
+		EnableParallelism:    enableParallelism,
 	}
 	_, err := runCommand(commandConfig)
 	if err != nil {

--- a/shell/utility.go
+++ b/shell/utility.go
@@ -21,11 +21,16 @@ type CommandConfig struct {
 	WorkingDirectory     string
 	Action               Action
 	PreviousOutput       map[string]string
+	EnableParallelism    bool
 }
 
 func runCommand(c *CommandConfig) (map[string]string, error) {
-	shellMutexKV.Lock(shellScriptMutexKey)
-	defer shellMutexKV.Unlock(shellScriptMutexKey)
+	if !c.EnableParallelism {
+		log.Printf("[DEBUG] parallelism disabled, locking")
+		shellMutexKV.Lock(shellScriptMutexKey)
+		defer shellMutexKV.Unlock(shellScriptMutexKey)
+		log.Printf("[DEBUG] lock acquired")
+	}
 
 	// Setup the command
 	shell := c.Interpreter[0]


### PR DESCRIPTION
Adding a new argument to the provider config to enable parallelism (default is false). This will make it harder to debug things, but also much faster.

```
provider "shell" {
	enable_parallelism = true
}

data "shell_script" "weather" {
 count = 100
  lifecycle_commands {
    read = <<-EOF
        echo "{\"SanFrancisco\": \"$(curl wttr.in/SanFrancisco?format="%l:+%c+%t")\"}"
    EOF
  }
}
```
For the above example, it is 5.2s vs 42.7s without parallelism turned on.
