### PR TITLE
remove all ForceNew from resource.shell_script schema

### DIFF
--- a/shell/data_source_shell_script.go
+++ b/shell/data_source_shell_script.go
@@ -15,14 +15,12 @@ func dataSourceShellScript() *schema.Resource {
 			"lifecycle_commands": {
 				Type:     schema.TypeList,
 				Required: true,
-				ForceNew: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"read": {
 							Type:     schema.TypeString,
 							Required: true,
-							ForceNew: true,
 						},
 					},
 				},
@@ -30,7 +28,6 @@ func dataSourceShellScript() *schema.Resource {
 			"environment": {
 				Type:     schema.TypeMap,
 				Optional: true,
-				ForceNew: true,
 				Elem:     schema.TypeString,
 			},
 			"sensitive_environment": {
@@ -42,7 +39,6 @@ func dataSourceShellScript() *schema.Resource {
 			"interpreter": {
 				Type:     schema.TypeList,
 				Optional: true,
-				ForceNew: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
@@ -50,7 +46,6 @@ func dataSourceShellScript() *schema.Resource {
 			"working_directory": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 				Default:  ".",
 			},
 			"output": {

--- a/shell/resource_shell_script.go
+++ b/shell/resource_shell_script.go
@@ -22,14 +22,12 @@ func resourceShellScript() *schema.Resource {
 			"lifecycle_commands": {
 				Type:     schema.TypeList,
 				Required: true,
-				ForceNew: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"create": {
 							Type:     schema.TypeString,
 							Required: true,
-							ForceNew: true,
 						},
 						"update": {
 							Type:     schema.TypeString,
@@ -38,7 +36,6 @@ func resourceShellScript() *schema.Resource {
 						"read": {
 							Type:     schema.TypeString,
 							Optional: true,
-							ForceNew: true,
 						},
 						"delete": {
 							Type:     schema.TypeString,
@@ -66,7 +63,6 @@ func resourceShellScript() *schema.Resource {
 			"interpreter": {
 				Type:     schema.TypeList,
 				Optional: true,
-				ForceNew: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
@@ -74,7 +70,6 @@ func resourceShellScript() *schema.Resource {
 			"working_directory": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 				Default:  ".",
 			},
 			"output": {


### PR DESCRIPTION
Fixes #59 
I removed them all - none make sense to me in any context : if you're changing say, interpreter or triggers, you know what you're doing. 

If the shell resource represents an actual resource (as opposed to a state-only construct), it seems to me that the most likely case is that no matter the change, you are still managing the same resource. You will therefore be able to refresh state either with `terraform refresh` (using read) or `terraform apply` (using update).

If the shell resource represents a state-only construct, delete is probably a no-op, and ForceNew never makes sense.

Given that the shell resource can represent anything, if the operator does need to destroy things before applying changes, `terraform destroy` can accommodate this rare need.

I'm happy to propose a fix limited to create/read if you find my argument unconvincing.