### PR TITLE
add an error_tag optional field to resource.shell_script

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ resource "shell_script" "github_repository" {
 		DESCRIPTION = "description"
 	}
 
-	
+
 	//sensitive environment variables are exactly the
 	//same as environment variables except they don't
 	//show up in log files
@@ -178,6 +178,11 @@ resource "shell_script" "github_repository" {
 	triggers = {
 		when_value_changed = var.some_value
 	}
+
+    //if your shell_script resource is in a module that is instanciated several
+    //times, an error_tag can help you figure out which precise resource is impacted
+    //in case of an error
+    error_tag = "repo for ${var.username}"
 }
 
 output "id" {
@@ -198,4 +203,3 @@ To run automated tests:
 ```sh
 $ make test
 ```
-

--- a/shell/resource_shell_script.go
+++ b/shell/resource_shell_script.go
@@ -87,6 +87,11 @@ func resourceShellScript() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"error_tag": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
 		},
 	}
 }
@@ -123,6 +128,7 @@ func create(d *schema.ResourceData, meta interface{}, stack []Action) error {
 	interpreter := getInterpreter(client, d)
 	workingDirectory := d.Get("working_directory").(string)
 	enableParallelism := client.config.EnableParallelism
+	errorTag := d.Get("error_tag").(string)
 	d.MarkNewResource()
 
 	commandConfig := &CommandConfig{
@@ -133,6 +139,7 @@ func create(d *schema.ResourceData, meta interface{}, stack []Action) error {
 		Interpreter:          interpreter,
 		Action:               ActionCreate,
 		EnableParallelism:    enableParallelism,
+		ErrorTag:             errorTag,
 	}
 	output, err := runCommand(commandConfig)
 	if err != nil {
@@ -180,6 +187,7 @@ func read(d *schema.ResourceData, meta interface{}, stack []Action) error {
 	workingDirectory := d.Get("working_directory").(string)
 	previousOutput := expandOutput(d.Get("output"))
 	enableParallelism := client.config.EnableParallelism
+	errorTag := d.Get("error_tag").(string)
 
 	commandConfig := &CommandConfig{
 		Command:              command,
@@ -190,6 +198,7 @@ func read(d *schema.ResourceData, meta interface{}, stack []Action) error {
 		Action:               ActionRead,
 		PreviousOutput:       previousOutput,
 		EnableParallelism:    enableParallelism,
+		ErrorTag:             errorTag,
 	}
 	output, err := runCommand(commandConfig)
 	if err != nil {
@@ -242,6 +251,7 @@ func update(d *schema.ResourceData, meta interface{}, stack []Action) error {
 	workingDirectory := d.Get("working_directory").(string)
 	previousOutput := expandOutput(d.Get("output"))
 	enableParallelism := client.config.EnableParallelism
+	errorTag := d.Get("error_tag").(string)
 
 	commandConfig := &CommandConfig{
 		Command:              command,
@@ -252,6 +262,7 @@ func update(d *schema.ResourceData, meta interface{}, stack []Action) error {
 		Action:               ActionDelete,
 		PreviousOutput:       previousOutput,
 		EnableParallelism:    enableParallelism,
+		ErrorTag:             errorTag,
 	}
 	output, err := runCommand(commandConfig)
 	if err != nil {
@@ -286,6 +297,7 @@ func delete(d *schema.ResourceData, meta interface{}, stack []Action) error {
 	workingDirectory := d.Get("working_directory").(string)
 	previousOutput := expandOutput(d.Get("output"))
 	enableParallelism := client.config.EnableParallelism
+	errorTag := d.Get("error_tag").(string)
 
 	commandConfig := &CommandConfig{
 		Command:              command,
@@ -296,6 +308,7 @@ func delete(d *schema.ResourceData, meta interface{}, stack []Action) error {
 		Action:               ActionDelete,
 		PreviousOutput:       previousOutput,
 		EnableParallelism:    enableParallelism,
+		ErrorTag:             errorTag,
 	}
 	_, err := runCommand(commandConfig)
 	if err != nil {

--- a/shell/resource_shell_script_test.go
+++ b/shell/resource_shell_script_test.go
@@ -45,6 +45,20 @@ func TestAccShellShellScript_basic_error(t *testing.T) {
 	})
 }
 
+func TestAccShellShellScript_basic_tagged_error(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckShellScriptDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccShellScriptConfig_basic_tagged_error(),
+				ExpectNonEmptyPlan: true,
+				ExpectError:        regexp.MustCompile("Tag: testErrorTag"),
+			},
+		},
+	})
+}
+
 func TestAccShellShellScript_create_read_delete(t *testing.T) {
 	resourceName := "shell_script.crd"
 	rString := acctest.RandString(8)
@@ -171,6 +185,26 @@ EOF
 		environment = {
 		  filename= "create_delete.json"
 		}
+	  }
+`)
+}
+
+func testAccShellScriptConfig_basic_tagged_error() string {
+	return fmt.Sprintf(`
+	resource "shell_script" "basic" {
+		lifecycle_commands {
+		  create = <<EOF
+		    echo "Something went wrong!"
+			exit 1
+EOF
+		  delete = "exit 1"
+		}
+
+		environment = {
+		  filename= "create_delete.json"
+		}
+
+		error_tag = "testErrorTag"
 	  }
 `)
 }

--- a/shell/utility.go
+++ b/shell/utility.go
@@ -22,6 +22,7 @@ type CommandConfig struct {
 	Action               Action
 	PreviousOutput       map[string]string
 	EnableParallelism    bool
+	ErrorTag             string
 }
 
 func runCommand(c *CommandConfig) (map[string]string, error) {
@@ -98,7 +99,11 @@ func runCommand(c *CommandConfig) (map[string]string, error) {
 
 	// If the script exited with a non-zero code then send the error up to Terraform
 	if err != nil {
-		return nil, fmt.Errorf("Error occurred during execution.\n Command: '%s' \n Error: '%s' \n StdOut: \n %s \n StdErr: \n %s", c.Command, err.Error(), stdOutput, stdError)
+		tagLine := ""
+		if c.ErrorTag != "" {
+			tagLine = fmt.Sprintf("Tag: %s\n ", c.ErrorTag)
+		}
+		return nil, fmt.Errorf("Error occurred during execution.\n Command: '%s' \n %sError: '%s' \n StdOut: \n %s \n StdErr: \n %s", c.Command, tagLine, err.Error(), stdOutput, stdError)
 	}
 
 	log.Printf("-------------------------")


### PR DESCRIPTION
This is a hack that addresses #60.

I believe the footprint to be reasonably small and that it has some merit.

I'm tempted to use a `DiffSuppressFunc` that disables the diff entirely for this field, hoping to trigger no changes at all when adding an `error_tag` or changing it - but that may be counter-intuitive ; and it would take some explaining - so I refrained. 

The biggest downside is that it's not very Terraformish. Maybe the real solution for #60 should be within Terraform itself.

The tests pass and I added an extra one, but I'm in no way sure that I did not break anything.

Feel free to close if you believe this fix is too much of a burden to maintain or ill designed.