### PR TITLE
fix empty previous output (#84)

### DIFF
--- a/shell/resource_shell_script.go
+++ b/shell/resource_shell_script.go
@@ -259,7 +259,8 @@ func read(d *schema.ResourceData, meta interface{}, stack []Action) error {
 	sensitiveEnvironment := formatEnvironmentVariables(sensitiveEnvVariables)
 	interpreter := getInterpreter(client, d)
 	workingDirectory := d.Get("working_directory").(string)
-	previousOutput := expandOutput(d.Get("output"))
+	o, _ := d.GetChange("output")
+	previousOutput := expandOutput(o)
 	enableParallelism := client.config.EnableParallelism
 
 	commandConfig := &CommandConfig{
@@ -346,7 +347,8 @@ func update(d *schema.ResourceData, meta interface{}, stack []Action) error {
 	sensitiveEnvironment := formatEnvironmentVariables(sensitiveEnvVariables)
 	interpreter := getInterpreter(client, d)
 	workingDirectory := d.Get("working_directory").(string)
-	previousOutput := expandOutput(d.Get("output"))
+	o, _ := d.GetChange("output")
+	previousOutput := expandOutput(o)
 	enableParallelism := client.config.EnableParallelism
 
 	commandConfig := &CommandConfig{
@@ -395,7 +397,8 @@ func delete(d *schema.ResourceData, meta interface{}, stack []Action) error {
 	sensitiveEnvironment := formatEnvironmentVariables(sensitiveEnvVariables)
 	interpreter := getInterpreter(client, d)
 	workingDirectory := d.Get("working_directory").(string)
-	previousOutput := expandOutput(d.Get("output"))
+	o, _ := d.GetChange("output")
+	previousOutput := expandOutput(o)
 	enableParallelism := client.config.EnableParallelism
 
 	commandConfig := &CommandConfig{


### PR DESCRIPTION
[SetNewComputed()](https://github.com/scottwinkler/terraform-provider-shell/blob/v1.7.6/shell/resource_shell_script.go#L171) in V1 sdk affect the result of [Get()](https://github.com/scottwinkler/terraform-provider-shell/blob/v1.7.6/shell/resource_shell_script.go#L349), rendering previous output to blank map. I think it is safe to use [GetChange()](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk@v1.7.0/helper/schema#ResourceData.GetChange) instead