### PR TITLE
Update logging descriptions

### DIFF
--- a/shell/resource_shell_script.go
+++ b/shell/resource_shell_script.go
@@ -283,8 +283,8 @@ func read(d *schema.ResourceData, meta interface{}, stack []Action) error {
 		d.SetId("")
 		return nil
 	}
-	log.Printf("[DEBUG] previous output:|%v|", output)
-	log.Printf("[DEBUG] new output:|%v|", previousOutput)
+	log.Printf("[DEBUG] previous output:|%v|", previousOutput)
+	log.Printf("[DEBUG] new output:|%v|", output)
 	isStateEqual := reflect.DeepEqual(output, previousOutput)
 	isNewResource := d.IsNewResource()
 	isUpdatedResource := stack[0] == ActionUpdate


### PR DESCRIPTION
If I've understood the code correctly, I think that the debug messages for previous/new output were switched. I'm interpretting `previousOutput` as the output from the previous execution of the provider, and `output` as the new output from the read operation that has just been performed - is that correct?