### PR TITLE
Add shell_sensitive_script data source and resource

### DIFF
--- a/shell/data_source_shell_script.go
+++ b/shell/data_source_shell_script.go
@@ -7,7 +7,7 @@ import (
 	"github.com/rs/xid"
 )
 
-func dataSourceShellScript() *schema.Resource {
+func dataSourceShellScript(sensitive_output bool) *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceShellScriptRead,
 
@@ -52,6 +52,7 @@ func dataSourceShellScript() *schema.Resource {
 				Type:     schema.TypeMap,
 				Computed: true,
 				Elem:     schema.TypeString,
+				Sensitive: sensitive_output,
 			},
 		},
 	}

--- a/shell/provider.go
+++ b/shell/provider.go
@@ -38,11 +38,13 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"shell_script": dataSourceShellScript(),
+			"shell_script": dataSourceShellScript(false),
+			"shell_sensitive_script": dataSourceShellScript(true),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"shell_script": resourceShellScript(),
+			"shell_script": resourceShellScript(false),
+			"shell_sensitive_script": resourceShellScript(true),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/shell/provider_test.go
+++ b/shell/provider_test.go
@@ -33,6 +33,7 @@ func TestProvider_impl(t *testing.T) {
 func TestProvider_HasChildResources(t *testing.T) {
 	expectedResources := []string{
 		"shell_script",
+		"shell_sensitive_script",
 	}
 
 	resources := testAccProvider.ResourcesMap
@@ -47,6 +48,7 @@ func TestProvider_HasChildResources(t *testing.T) {
 func TestProvider_HasChildDataSources(t *testing.T) {
 	expectedDataSources := []string{
 		"shell_script",
+		"shell_sensitive_script",
 	}
 
 	dataSources := testAccProvider.DataSourcesMap

--- a/shell/resource_shell_script.go
+++ b/shell/resource_shell_script.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rs/xid"
 )
 
-func resourceShellScript() *schema.Resource {
+func resourceShellScript(sensitive_output bool) *schema.Resource {
 	return &schema.Resource{
 		Create: resourceShellScriptCreate,
 		Delete: resourceShellScriptDelete,
@@ -78,6 +78,7 @@ func resourceShellScript() *schema.Resource {
 				Type:     schema.TypeMap,
 				Computed: true,
 				Elem:     schema.TypeString,
+				Sensitive: sensitive_output,
 			},
 			"dirty": {
 				Type:     schema.TypeBool,

--- a/website/docs/d/shell_sensitive_script.html.markdown
+++ b/website/docs/d/shell_sensitive_script.html.markdown
@@ -1,0 +1,42 @@
+---
+layout: "shell"
+page_title: "Shell: shell_sensitive_script"
+sidebar_current: "docs-shell-data-source"
+description: |-
+  Shell script custom data source
+---
+
+# shell_script
+
+The `shell_sensitive_script` data shares the same interface as the `shell_script` data, but its output is sensitive. As a result, the output will not be exposed in the logs.
+
+
+## Example Usage
+
+```hcl
+variable "token" {
+  type = string
+}
+
+data "shell_sensitive_script" "secret" {
+  lifecycle_commands {
+    read = <<-EOF
+      set -e
+      secret=$(curl "https://example.com/secret" -H "Authorization: Basic $TOKEN")
+      jq --null-input --arg secret "$secret" '{"value": $secret}'
+    EOF
+  }
+  sensitive_environment = {
+    TOKEN = var.token
+  }
+}
+
+output "secret" {
+  value = data.shell_sensitive_script.secret.output["value"]
+  sensitive = true
+}
+```
+
+## Attributes Reference
+
+* `output` - A map of outputs

--- a/website/docs/r/shell_sensitive_script_resource.html.markdown
+++ b/website/docs/r/shell_sensitive_script_resource.html.markdown
@@ -1,0 +1,38 @@
+---
+layout: "shell"
+page_title: "Shell: shell_sensitive_script"
+sidebar_current: "docs-shell-resource"
+description: |-
+  Shell script custom resource
+---
+
+# shell_script
+
+The `shell_sensitive_script` resource shares the same interface as the `shell_script` resource, but its output is sensitive. As a result, the output will not be exposed in the logs.
+
+## Example Usage
+
+```hcl
+resource "shell_sensitive_script" "special_secret" {
+  lifecycle_commands {
+    create = <<EOF
+      set -e
+      secret=$(openssl rand -hex 32)
+      jq --null-input --arg secret "$secret" '{"value": $secret}'
+    EOF
+    delete = <<EOF
+      # nothing
+    EOF
+  }
+}
+output "special_secret" {
+  value     = shell_sensitive_script.special_secret.output["value"]
+  sensitive = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `output` - A map of outputs

--- a/website/shell.erb
+++ b/website/shell.erb
@@ -5,31 +5,37 @@
           <li<%= sidebar_current("docs-home") %>>
           <a href="/docs/providers/index.html">All Providers</a>
           </li>
-  
+
           <li<%= sidebar_current("docs-shell-index") %>>
           <a href="/docs/providers/shell/index.html">Shell Provider</a>
           </li>
-  
+
           <li<%= sidebar_current("docs-shell-datasource") %>>
             <a href="#">Data Sources</a>
             <ul class="nav nav-visible">
               <li<%= sidebar_current("docs-shell-datasource") %>>
                 <a href="/docs/providers/shell/d/shell_script_data_source.html">shell_script</a>
               </li>
+              <li<%= sidebar_current("docs-shell-datasource") %>>
+                <a href="/docs/providers/shell/d/shell_sensitive_script_data_source.html">shell_script</a>
+              </li>
             </ul>
           </li>
-  
+
           <li<%= sidebar_current("docs-shell-resource") %>>
           <a href="#">Resources</a>
           <ul class="nav nav-visible">
             <li<%= sidebar_current("docs-shell-resource") %>>
               <a href="/docs/providers/shell/r/shell_script_resource.html">shell_script</a>
             </li>
+            <li<%= sidebar_current("docs-shell-resource") %>>
+              <a href="/docs/providers/shell/r/shell_sensitive_script_resource.html">shell_script</a>
+            </li>
           </ul>
           </li>
         </ul>
       </div>
     <% end %>
-  
+
     <%= yield %>
     <% end %>


### PR DESCRIPTION
`shell_script` exposes the output value in logs. This pr adds a sensitive version of `shell_script`, which just marks `Sensitive: true` for `output` in the schema.

This should fix <https://github.com/scottwinkler/terraform-provider-shell/issues/92>.
